### PR TITLE
Add course guides for auth/authz

### DIFF
--- a/content/blog/2025-09-11-cloud-computing.md
+++ b/content/blog/2025-09-11-cloud-computing.md
@@ -1,6 +1,7 @@
 ---
 date: "2026-03-21T00:00:00Z"
 title: "Guía de cátedra 2026: Cloud Computing"
+description: "Guía de cátedra sobre cloud computing para 2026: proveedores, free tiers, stacks recomendados, despliegue y criterios de costo para los proyectos."
 tags:
   - cloud-computing
   - aws
@@ -12,10 +13,6 @@ tags:
   - terraform
   - microservicios
   - 2026-1C
----
-
-_Actualizado al 21-mar-2026_
-
 ---
 
 ## TL;DR

--- a/content/blog/2026-04-03-auth.md
+++ b/content/blog/2026-04-03-auth.md
@@ -43,11 +43,11 @@ OIDC resuelve identidad/login. La authz fina puede apoyarse en claims o scopes, 
 
 | Producto                      | Modelo mental                                                                                  | Operación                                                             | Dependencias                                                          | OIDC / JWT externo                                                                                           | Rate limiting                                                            |
 | :---------------------------- | :--------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
-| **KrakenD CE**                | Declarativo, BFF/agregación ([KrakenD][9])                                                     | Muy buena; Dockerfile inmutable ([KrakenD][10])                       | Sin DB/Redis ([KrakenD][10])                                          | Fit nativo; Firebase/Google explícito ([KrakenD][1])                                                         | `max_rate` + `client_max_rate`, en memoria ([KrakenD][14])               |
-| **Apache APISIX**             | Gateway de plugins, cloud-native ([APISIX][2])                                                 | Standalone reduce ops, pero exige más config explícita ([APISIX][11]) | Sin etcd en Standalone ([APISIX][11])                                 | Plugin `openid-connect`; Google y otros IdP ([APISIX][2])                                                    | `limit-count` (fixed window) + `limit-req` (leaky bucket) ([APISIX][15]) |
-| **Tyk OSS**                   | _Batteries included_, fuerte en policies ([Tyk][3])                                            | Fácil de levantar, arrastra Redis ([Tyk][7])                          | Redis obligatorio ([Tyk][7])                                          | JWT + JWKS URIs; buen fit con IdP externo ([Tyk][13])                                                        | API-level y Key-level ([Tyk][16])                                        |
 | **Traefik OSS + ForwardAuth** | Application proxy; auth en servicio externo ([Traefik Features][5], [Traefik ForwardAuth][29]) | Muy buena; hot reload, labels/CRDs ([Traefik Docker][28])             | Sin DB; auth depende del servicio externo ([Traefik ForwardAuth][29]) | JWT/OIDC nativo solo en Hub; en OSS se delega por `ForwardAuth` ([Traefik Features][5])                      | Token bucket con middleware `RateLimit` ([Traefik RateLimit][12])        |
+| **KrakenD CE**                | Declarativo, BFF/agregación ([KrakenD][9])                                                     | Muy buena; Dockerfile inmutable ([KrakenD][10])                       | Sin DB/Redis ([KrakenD][10])                                          | Fit nativo; Firebase/Google explícito ([KrakenD][1])                                                         | `max_rate` + `client_max_rate`, en memoria ([KrakenD][14])               |
+| **Tyk OSS**                   | _Batteries included_, fuerte en policies ([Tyk][3])                                            | Fácil de levantar, arrastra Redis ([Tyk][7])                          | Redis obligatorio ([Tyk][7])                                          | JWT + JWKS URIs; buen fit con IdP externo ([Tyk][13])                                                        | API-level y Key-level ([Tyk][16])                                        |
 | **Kong OSS**                  | Plugin-based, muy flexible ([Kong][4])                                                         | DB-less simplifica bastante ([Kong][4])                               | Sin DB en modo DB-less ([Kong][4])                                    | JWT emitido por el equipo: OK. OIDC/Firebase directo: fricción (Enterprise) ([Kong JWT][25], [Kong OIDC][8]) | Local, cluster, Redis ([Kong][17])                                       |
+| **Apache APISIX**             | Gateway de plugins, cloud-native ([APISIX][2])                                                 | Standalone reduce ops, pero exige más config explícita ([APISIX][11]) | Sin etcd en Standalone ([APISIX][11])                                 | Plugin `openid-connect`; Google y otros IdP ([APISIX][2])                                                    | `limit-count` (fixed window) + `limit-req` (leaky bucket) ([APISIX][15]) |
 
 **Sin Kubernetes:** todas estas opciones pueden correrse con contenedores. ([KrakenD][10], [APISIX][26], [Tyk][3], [Kong Docker][27], [Traefik Docker][28])
 
@@ -57,7 +57,28 @@ OIDC resuelve identidad/login. La authz fina puede apoyarse en claims o scopes, 
 
 La decisión principal no es Firebase sí o no, sino `IdP externo` versus `auth propia`. La elección pasa por control, responsabilidades operativas, evidencia de garantías de seguridad, costo de migración y tiempo de implementación. En esta guía, Firebase aparece como ejemplo frecuente, pero el mismo patrón aplica a Clerk u otros proveedores OIDC equivalentes. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30])
 
-### IdP externo (OIDC) + gateway
+**Regla de decisión**
+
+Un `IdP externo` no queda legitimado solo por ahorrar tiempo. Solo es defendible si el equipo puede explicar qué requisitos cubre el proveedor, cuáles siguen bajo responsabilidad propia y con qué evidencia va a sostener esa decisión ante la cátedra. Si esa defensa no puede hacerse con precisión, corresponde `auth propia`.
+
+### Auth propia
+
+El equipo implementa su propia capa de identidad y sesión para la plataforma: registro, login, hash de contraseñas, recupero, refresh token, emisión de JWT y, si hace falta, claims o roles globales para la API.
+
+Eso no reemplaza el estado propio del dominio ni la capa de autorización: `blocked`, ownership, permisos finos y reglas de negocio siguen fuera de esta capa. También conviene distinguir una auth propia para la app de un authorization server OAuth/OIDC completo para terceros: lo segundo es bastante más ambicioso.
+
+Hoy, además, no implica necesariamente escribir todo desde cero; existen frameworks y librerías maduras como Spring Authorization Server, las herramientas de seguridad de FastAPI para OAuth2/JWT o `node-oidc-provider`. Aun así, la implementación, operación y seguridad siguen siendo responsabilidad del equipo. ([OWASP Passwords][35], [Spring Auth Server][36], [FastAPI Security][37], [node-oidc-provider][38])
+
+| Trade-off     | Detalle                                                                                                                                                                                                                                                |
+| :------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A favor**   | Control total sobre identidad, sesiones y claims de plataforma. Muy buena opción si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías implementadas por ellos mismos.                                               |
+| **A favor**   | Con librerías modernas, el volumen de código commodity puede ser bastante menor de lo que sugiere la intuición inicial.                                                                                                                                |
+| **En contra** | El equipo pasa a ser responsable de cerrar bien autenticación, sesiones, recupero, almacenamiento seguro, revocación, auditoría y mitigaciones de abuso. Las librerías ayudan, pero no reemplazan diseño ni revisión de seguridad. ([OWASP AuthN][39]) |
+| **En contra** | Si además se quiere exponer un authorization server OAuth/OIDC completo y reutilizable para terceros, la complejidad sube respecto de una auth propia solo para la app.                                                                                |
+
+---
+
+### IdP externo + gateway
 
 El cliente mobile se autentica con un proveedor externo de identidad y usa ese token directamente contra el gateway. Firebase aparece acá solo como ejemplo frecuente, no como caso rector del documento. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30])
 
@@ -86,21 +107,6 @@ El cliente sigue logueando con un proveedor externo, pero el auth service valida
 | **A favor**   | Claims completamente propias; mayor independencia del IdP; cambiar de proveedor afecta menos a los servicios.                                                                                                                                      |
 | **En contra** | Hay que resolver la renovación (refresh token propio o re-exchange contra el proveedor externo); más superficie de implementación. Conviene solo si el equipo puede justificar técnicamente el valor que gana. ([Firebase][21], [Clerk Token][31]) |
 
-### Auth propia
-
-El equipo implementa su propia capa de identidad y sesión para la plataforma: registro, login, hash de contraseñas, recupero, refresh token, emisión de JWT y, si hace falta, claims o roles globales para la API.
-
-Eso no reemplaza el estado propio del dominio ni la capa de autorización: `blocked`, ownership, permisos finos y reglas de negocio siguen fuera de esta capa. También conviene distinguir una auth propia para la app de un authorization server OAuth/OIDC completo para terceros: lo segundo es bastante más ambicioso. Hoy, además, no implica necesariamente escribir todo desde cero; existen frameworks y librerías maduras como Spring Authorization Server, las herramientas de seguridad de FastAPI para OAuth2/JWT o `node-oidc-provider`. Aun así, la implementación, operación y seguridad siguen siendo responsabilidad del equipo. ([OWASP Passwords][35], [Spring Auth Server][36], [FastAPI Security][37], [node-oidc-provider][38])
-
-| Trade-off     | Detalle                                                                                                                                                                                                                                                |
-| :------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **A favor**   | Control total sobre identidad, sesiones y claims de plataforma. Muy buena opción si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías implementadas por ellos mismos.                                               |
-| **A favor**   | Con librerías modernas, el volumen de código commodity puede ser bastante menor de lo que sugiere la intuición inicial.                                                                                                                                |
-| **En contra** | El equipo pasa a ser responsable de cerrar bien autenticación, sesiones, recupero, almacenamiento seguro, revocación, auditoría y mitigaciones de abuso. Las librerías ayudan, pero no reemplazan diseño ni revisión de seguridad. ([OWASP AuthN][39]) |
-| **En contra** | Si además se quiere exponer un authorization server OAuth/OIDC completo y reutilizable para terceros, la complejidad sube respecto de una auth propia solo para la app.                                                                                |
-
----
-
 ## Opciones de IdP
 
 Además de elegir gateway, conviene decidir quién resuelve identidad y sesión. En esta guía aparecen tres familias:
@@ -113,7 +119,7 @@ Todas pueden encajar con el patrón `IdP + gateway`: el proveedor resuelve login
 
 {{< youtube 5KChrGWFcpk >}}
 
-### IdP externo + gateway
+### IdP externos
 
 Este patrón conviene cuando el objetivo no es construir identidad desde cero, sino llegar rápido a una API protegida con login razonable, sesión larga y validación de tokens.
 
@@ -125,15 +131,20 @@ Este patrón conviene cuando el objetivo no es construir identidad desde cero, s
 | **Auth0**                   | Plataforma de identidad más enterprise         | Hasta `25.000` MAUs en Free; passwordless, social login, custom domain y una enterprise connection. ([Auth0 Pricing][46], [Auth0 Custom Domains][47], [Auth0 Passwordless][48])                                                                                 | Muy completo, pero puede sentirse más pesado que otras opciones de esta guía.                                                                                                                      |
 | **Keycloak**                | IdP self-hosted / authorization server         | OIDC, OAuth2 y SAML; consola admin centralizada; federation y Authorization Services. ([Keycloak][49], [Keycloak Authz][33])                                                                                                                                    | Mucho resuelto sin escribir auth propia, pero hay que operarlo: contenedor, DB relacional y configuración propia del servicio. ([Keycloak Container][50], [Keycloak DB][51], [Keycloak Admin][52]) |
 
-### Cuándo conviene
-
-- **Si el foco está en llegar rápido a login, sesión y recuperación**, un IdP externo reduce bastante la superficie de implementación.
-- **Si se quiere más control sin implementar auth propia**, Keycloak resuelve mucho, pero agrega operación.
-- **Si hay que demostrar garantías muy específicas** sobre reset, revocación, hashing o storage del token, conviene distinguir con cuidado entre controles propios, self-hosted y delegados al proveedor.
-
 Ninguna de estas plataformas reemplaza al gateway, a la DB propia del dominio ni a la autorización fina. En otras palabras: **identidad y sesión pueden delegarse; autorización fina y enforcement final, no**. ([OAuth Resource Server][34], [OPA][32], [Keycloak Authz][33])
 
 ---
+
+### Criterio de validez
+
+Un `IdP externo` solo es defendible si el equipo puede demostrar, con documentación oficial y diseño propio, los controles que realmente delega:
+
+- login, registro y recupero;
+- sesión y refresh, si aplica;
+- hashing de contraseñas con `BCrypt` o equivalente, siempre que el sistema elegido lo resuelva;
+- tokens de recupero con TTL, single-use y tratamiento seguro, siempre que el sistema elegido cubra esas garantías;
+
+Si el proveedor no permite demostrar alguno de esos puntos, no alcanza con responder "eso lo maneja el IdP". En ese caso, para efectos de arquitectura y corrección, la opción no queda legitimada y conviene pasar a `auth propia`, que sí permite implementar y probar todos los controles requeridos.
 
 ## Matices con IdP externos
 
@@ -149,9 +160,10 @@ Firebase soporta custom claims para roles globales tipo `admin`, pero no están 
 
 **Password reset y hashing**
 
-Firebase envía password reset emails con expiración del código y single-use del flujo. Lo que no está verificable en documentación oficial es un TTL máximo de 1 hora ni el almacenamiento hasheado del token del lado del proveedor. Si la materia exige demostrar esas garantías, hay que implementarlas en un auth service propio. ([Firebase][23])
+Firebase envía password reset emails con expiración del código y single-use del flujo. Lo que no está verificable en documentación oficial es un TTL máximo de 1 hora ni el almacenamiento hasheado del token del lado del proveedor. Si el sistema elegido no cubre esas garantías con claridad, hay que implementarlas en un auth service propio. ([Firebase][23])
 
-Si se exige BCrypt u otro algoritmo adaptativo: las contraseñas que viven en Firebase nunca tocan la DB propia, así que el hashing queda delegado al proveedor. Firebase usa por defecto una versión modificada de `scrypt` — probablemente "otro algoritmo adaptativo" — pero sigue siendo un control delegado. ([Firebase][22])
+Respecto del hashing de contraseñas: las contraseñas que viven en Firebase nunca tocan la DB propia, así que el hashing queda delegado al proveedor. Firebase usa por defecto una versión modificada de `scrypt` — probablemente "otro algoritmo adaptativo" — pero sigue siendo un control delegado. ([Firebase][22])
+
 
 ---
 
@@ -191,7 +203,8 @@ Si se exige BCrypt u otro algoritmo adaptativo: las contraseñas que viven en Fi
 4. **Confiar únicamente en claims externas para reglas finas.** `admin=true` no valida "este recurso es de este usuario". ([Firebase][20])
 5. **Asumir revocación/disable instantáneos sobre tokens ya emitidos.** El gateway que valida offline por firma/JWKS no se entera automáticamente. ([Firebase][21])
 6. **Afirmar atributos de seguridad que no pueden demostrarse.** Si el reset o el hashing están delegados al proveedor, no inventar detalles técnicos sobre código que no controlan.
-7. **Asumir que la authz fina debe vivir exclusivamente en cada microservicio o, al revés, exclusivamente en el gateway.** La decisión puede centralizarse, pero necesita datos del dominio y un enforcement claro cerca del recurso protegido. ([OPA][32], [Keycloak Authz][33])
+7. **Elegir un IdP externo como salida rápida sin justificar la decisión.** Si no hay una defensa explícita de qué garantías cubre, qué queda delegado y por qué eso sigue cumpliendo la consigna, la decisión está floja de base.
+8. **Asumir que la authz fina debe vivir exclusivamente en cada microservicio o, al revés, exclusivamente en el gateway.** La decisión puede centralizarse, pero necesita datos del dominio y un enforcement claro cerca del recurso protegido. ([OPA][32], [Keycloak Authz][33])
 
 ---
 
@@ -203,6 +216,7 @@ Si se exige BCrypt u otro algoritmo adaptativo: las contraseñas que viven en Fi
 - ¿Dónde se persiste el estado del usuario (bloqueo, roles, flags de negocio)?
 - ¿Qué garantías quedan delegadas al proveedor, cuáles implementadas por el equipo, y qué brechas quedan asumidas?
 - ¿Qué nivel de acoplamiento al proveedor aceptan y cuánto costaría migrar?
+- ¿Por qué esa elección es defendible ante la cátedra y no solo una reducción de esfuerzo?
 
 ---
 

--- a/content/blog/2026-04-03-auth.md
+++ b/content/blog/2026-04-03-auth.md
@@ -1,0 +1,217 @@
+---
+date: "2026-04-03T00:00:00Z"
+title: "Guía de cátedra 2026: API Gateway + Auth/Authz"
+description: "Guía de cátedra sobre autenticación, autorización y API Gateway para 2026: auth propia, IdP externos, manejo de sesión y criterios para elegir gateway."
+tags:
+  - cloud-computing
+  - microservicios
+  - 2026-1C
+---
+
+## TL;DR
+
+
+| Cuándo | Opción | Trade-off principal |
+| :----- | :----- | :------------------ |
+| **Control total** | **Auth propia** | Más control y más garantías demostrables, pero también más diseño, operación y revisión. ([OWASP Passwords][35], [OWASP AuthN][39], [Spring Auth Server][36]) |
+| **Proxy simple** | **Traefik OSS + ForwardAuth** | Routing simple; la auth se delega a otro servicio. ([Traefik Features][5], [Traefik ForwardAuth][29], [Traefik Docker][28]) |
+| **BFF simple** | **KrakenD CE** | Declarativo, JWT/OIDC y pocas dependencias. ([KrakenD][1]) |
+| **Policies y cuotas** | **Tyk OSS** | Muy completo, pero con Redis como costo operativo. ([Tyk][3]) |
+| **JWT del equipo en gateway** | **Kong OSS** | Encaja con JWT propio; OIDC directo en OSS suma fricción. ([Kong DB-less][4], [Kong JWT][25], [Kong OIDC][8]) |
+| **Extensibilidad** | **Apache APISIX** | Muy flexible, pero con más configuración explícita. ([Apache APISIX][2]) |
+| **Delegar identidad** | **IdP externo + gateway** | Menos complejidad en login y sesión, pero más garantías delegadas al proveedor. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30]) |
+| **Token del equipo** | **IdP externo + JWT propio** | Desacopla a los servicios del IdP, pero agrega exchange, refresh y operación. ([OpenID Connect][40], [Firebase][21], [Clerk Token][31]) |
+
+---
+
+## Responsabilidades
+
+Más allá del stack elegido, conviene separar el sistema en cuatro capas. Cada una resuelve un problema distinto y no debería invadir por completo a las demás.
+
+**Identidad y sesión.** La resuelve un proveedor de identidad o una plataforma de auth, como Firebase Auth, Clerk o un servicio propio. Esta capa se ocupa de registro, login, recuperación de credenciales y manejo de sesión.
+
+**Gateway / Proxy.** Valida el token, o delega esa validación, cierra rutas, aplica rate limiting grueso y, cuando corresponde, hace agregación tipo BFF. Muchos además traen soporte o plugins para JWT/OIDC y pueden resolver authz gruesa basada en scopes, claims o integración con un servicio externo.
+
+**Autorización.** Define si un usuario puede o no hacer una acción concreta. Esa decisión puede vivir dentro de cada servicio o centralizarse en un auth service o policy engine. Lo importante es que use reglas reales del dominio, no solo claims del token. ([OPA][32], [Keycloak Authz][33])
+
+**Servicios de dominio.** Son el último punto de enforcement. Aunque el gateway filtre y el token sea válido, acá se decide finalmente sobre recursos, ownership, bloqueos, flags de negocio y cualquier regla que dependa del estado real del sistema.
+
+OIDC resuelve identidad/login. La authz fina puede apoyarse en claims o scopes, pero no debería depender solo de eso ni solo del gateway. ([OAuth Resource Server][34])
+
+{{< youtube iX8g4LqF8p8 >}}
+
+---
+
+## Gateways y Proxies
+
+| Producto                      | Cuándo elegirlo                         | Modelo mental                                                                                  | Operación                                                             | Dependencias                                                          | OIDC / JWT externo                                                                            | Rate limiting                                                            |
+| :---------------------------- | :-------------------------------------- | :--------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
+| **KrakenD CE**                | Simplicidad + BFF sin extras            | Declarativo, BFF/agregación ([KrakenD][9])                                                     | Muy buena; Dockerfile inmutable ([KrakenD][10])                       | Sin DB/Redis ([KrakenD][10])                                          | Fit nativo; Firebase/Google explícito ([KrakenD][1])                                          | `max_rate` + `client_max_rate`, en memoria ([KrakenD][14])               |
+| **Apache APISIX**             | Máxima flexibilidad de plugins          | Gateway de plugins, cloud-native ([APISIX][2])                                                 | Standalone reduce ops, pero exige más config explícita ([APISIX][11]) | Sin etcd en Standalone ([APISIX][11])                                 | Plugin `openid-connect`; Google y otros IdP ([APISIX][2])                                     | `limit-count` (fixed window) + `limit-req` (leaky bucket) ([APISIX][15]) |
+| **Tyk OSS**                   | Rate limiting avanzado; se acepta Redis | _Batteries included_, fuerte en policies ([Tyk][3])                                            | Fácil de levantar, arrastra Redis ([Tyk][7])                          | Redis obligatorio ([Tyk][7])                                          | JWT + JWKS URIs; buen fit con IdP externo ([Tyk][13])                                         | API-level y Key-level ([Tyk][16])                                        |
+| **Traefik OSS + ForwardAuth** | Edge router liviano; auth delegada      | Application proxy; auth en servicio externo ([Traefik Features][5], [Traefik ForwardAuth][29]) | Muy buena; hot reload, labels/CRDs ([Traefik Docker][28])             | Sin DB; auth depende del servicio externo ([Traefik ForwardAuth][29]) | JWT/OIDC nativo solo en Hub; en OSS se delega por `ForwardAuth` ([Traefik Features][5])       | Token bucket con middleware `RateLimit` ([Traefik RateLimit][12])        |
+| **Kong OSS**                  | El equipo emite su propio JWT           | Plugin-based, muy flexible ([Kong][4])                                                         | DB-less simplifica bastante ([Kong][4])                               | Sin DB en modo DB-less ([Kong][4])                                    | JWT emitido por el equipo: OK. OIDC/Firebase directo: fricción (Enterprise) ([Kong JWT][25], [Kong OIDC][8]) | Local, cluster, Redis ([Kong][17])                                       |
+
+**Sin Kubernetes:** todas estas opciones pueden correrse con contenedores. ([KrakenD][10], [APISIX][26], [Tyk][3], [Kong Docker][27], [Traefik Docker][28])
+
+---
+
+## Identidad y sesión
+
+La decisión principal no es Firebase sí o no, sino `IdP externo` versus `auth propia`. La elección pasa por control, responsabilidades operativas, evidencia de garantías de seguridad, costo de migración y tiempo de implementación. En esta guía, Firebase aparece como ejemplo frecuente, pero el mismo patrón aplica a Clerk u otros proveedores OIDC equivalentes. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30])
+
+### IdP externo (OIDC) + gateway
+
+El cliente mobile se autentica con un proveedor externo de identidad y usa ese token directamente contra el gateway. Firebase aparece acá solo como ejemplo frecuente, no como caso rector del documento. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30])
+
+**Flujo**
+
+1. El cliente autentica con un proveedor externo compatible con OIDC, por ejemplo Firebase Auth, Clerk u otro IdP equivalente. ([OpenID Connect][40], [Firebase][6], [Clerk Expo][30])
+2. El proveedor entrega el token de identidad o sesión según el flujo elegido.
+3. El cliente manda ese token al gateway.
+4. El gateway valida el token o delega la validación al componente correspondiente.
+5. El backend o la capa de autorización verifica `blocked`, `roles`, ownership y reglas de negocio contra estado confiable del dominio.
+6. Cuando el token vence, el cliente renueva la sesión según el mecanismo del proveedor o del auth service.
+
+**Pros y contras**
+
+| Trade-off     | Detalle                                                                                                                                                                                                                     |
+| :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A favor**   | Menor superficie a implementar; sesión larga y renovación ya resueltas; flujos de email/password y login federado disponibles según el proveedor elegido. ([Firebase][19], [Clerk Expo][30])                                |
+| **En contra** | Parte de la lógica queda fuera del control del equipo. Según el proveedor, puede no haber evidencia documental suficiente para ciertas garantías duras; en Firebase, por ejemplo, no está verificable un TTL máximo de 1h para reset ni storage hasheado del token. |
+
+### IdP externo + JWT propio
+
+El cliente sigue logueando con un proveedor externo, pero el auth service valida ese token y emite un JWT propio de la plataforma, es decir, un token emitido por el equipo para su API. El gateway valida ese token propio.
+
+| Trade-off     | Detalle                                                                                                                                                                                                                                            |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A favor**   | Claims completamente propias; mayor independencia del IdP; cambiar de proveedor afecta menos a los servicios.                                                                                                                                      |
+| **En contra** | Hay que resolver la renovación (refresh token propio o re-exchange contra el proveedor externo); más superficie de implementación. Conviene solo si el equipo puede justificar técnicamente el valor que gana. ([Firebase][21], [Clerk Token][31]) |
+
+### Auth propia
+
+El equipo implementa su propia capa de identidad y sesión para la plataforma: registro, login, hash de contraseñas, recupero, refresh token, emisión de JWT y, si hace falta, claims o roles globales para la API.
+
+Eso no reemplaza el estado propio del dominio ni la capa de autorización: `blocked`, ownership, permisos finos y reglas de negocio siguen fuera de esta capa. También conviene distinguir una auth propia para la app de un authorization server OAuth/OIDC completo para terceros: lo segundo es bastante más ambicioso. Hoy, además, no implica necesariamente escribir todo desde cero; existen frameworks y librerías maduras como Spring Authorization Server, las herramientas de seguridad de FastAPI para OAuth2/JWT o `node-oidc-provider`. Aun así, la implementación, operación y seguridad siguen siendo responsabilidad del equipo. ([OWASP Passwords][35], [Spring Auth Server][36], [FastAPI Security][37], [node-oidc-provider][38])
+
+| Trade-off     | Detalle                                                                                                                                                   |
+| :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A favor**   | Control total sobre identidad, sesiones y claims de plataforma. Muy buena opción si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías implementadas por ellos mismos. |
+| **A favor**   | Con librerías modernas, el volumen de código commodity puede ser bastante menor de lo que sugiere la intuición inicial.                                                                                   |
+| **En contra** | El equipo pasa a ser responsable de cerrar bien autenticación, sesiones, recupero, almacenamiento seguro, revocación, auditoría y mitigaciones de abuso. Las librerías ayudan, pero no reemplazan diseño ni revisión de seguridad. ([OWASP AuthN][39]) |
+| **En contra** | Si además se quiere exponer un authorization server OAuth/OIDC completo y reutilizable para terceros, la complejidad sube respecto de una auth propia solo para la app.                                 |
+
+---
+
+## Matices con IdP externos
+
+Los proveedores externos resuelven bien login, sesión, recupero e integración federada, pero no reemplazan el estado propio del dominio ni la autorización fina. En esta guía se usa Firebase como ejemplo frecuente por su adopción en mobile, no como única opción válida. Trabajar sobre OIDC/OAuth2 reduce el costo de cambio, aunque no elimina por completo el vendor lock-in. ([OpenID Connect][40], [Firebase][19])
+
+**Sesión, claims, revocación y bloqueo**
+
+Aunque Firebase permite gestionar usuarios y aprovisionarlos deshabilitados, eso no reemplaza el estado propio del dominio. Sigue siendo necesario persistir `user_id interno`, `blocked`, `roles`, `created_at` y flags de negocio; y no depender solo de claims externas para authz fina.
+
+La razón es concreta: `verifyIdToken()` por sí solo no chequea revocación, y un gateway que valida offline por firma/JWKS tampoco ve instantáneamente `disabled=true` ni una revocación. Los ID tokens ya emitidos pueden seguir válidos hasta su expiración natural. Por eso `blocked`, roles reales y reglas finas deben consultarse contra estado propio del dominio, ya sea dentro del servicio o a través de una capa central de autorización. ([Firebase][21], [OPA][32])
+
+Firebase soporta custom claims para roles globales tipo `admin`, pero no están pensadas para datos estructurados de negocio, y los cambios se reflejan solo cuando el usuario reautentica o refresca el token. **Claim o scope para authz gruesa; dominio o capa de autorización para authz fina.** ([Firebase][20], [OAuth Resource Server][34])
+
+**Password reset y hashing**
+
+Firebase envía password reset emails con expiración del código y single-use del flujo. Lo que no está verificable en documentación oficial es un TTL máximo de 1 hora ni el almacenamiento hasheado del token del lado del proveedor. Si la materia exige demostrar esas garantías, hay que implementarlas en un auth service propio. ([Firebase][23])
+
+Si se exige BCrypt u otro algoritmo adaptativo: las contraseñas que viven en Firebase nunca tocan la DB propia, así que el hashing queda delegado al proveedor. Firebase usa por defecto una versión modificada de `scrypt` — probablemente "otro algoritmo adaptativo" — pero sigue siendo un control delegado. ([Firebase][22])
+
+---
+
+## Responsabilidades por capa
+
+| Responsabilidad                           | ¿Pasa por el gateway?        | Dónde se implementa                                 |
+| :---------------------------------------- | :--------------------------- | :-------------------------------------------------- |
+| Login federado con Google (optativo)      | No (valida el token después) | Proveedor de identidad                              |
+| Login con email/password                  | No                           | IdP o auth service propio                           |
+| Registro con email/password               | No                           | IdP o auth service propio                           |
+| Recupero de contraseña                    | No                           | IdP o auth service propio                           |
+| Hash de contraseñas (ej. BCrypt o scrypt) | No                           | Delegado al IdP o auth service propio               |
+| Reglas mínimas de contraseña              | No                           | Depende del approach de auth elegido                |
+| Renovación de sesión                      | No                           | Depende del approach de auth elegido                |
+| Emisión del token de API                  | No (solo valida)             | IdP o auth service                                  |
+| Validación del token de API               | Sí                           | Gateway                                             |
+| Decisión de autorización fina             | No                           | Servicios de dominio o capa central de autorización |
+| Rate limiting por IP                      | Sí                           | Gateway                                             |
+| Rate limiting por cuenta/email            | Parcial (ver nota)           | Auth service                                        |
+| Bloqueo de usuario                        | No                           | Backend + DB de dominio                             |
+| Roles básicos (`user`/`admin`)            | Parcial (claims gruesas)     | Estado real en DB propia                            |
+| Ownership y permisos finos                | No                           | Enforcement final en backend con datos del dominio  |
+| Minimización de datos                     | No                           | Backend del dominio                                 |
+| Ocultar recursos de usuario bloqueado     | No                           | Backend + queries de dominio                        |
+| Idempotencia de operaciones críticas      | No                           | Servicios de dominio                                |
+| `/livez` y `/readyz`                      | No                           | Cada servicio, incluido auth/user                   |
+
+**Nota sobre rate limiting por cuenta/email:** El gateway resuelve bien rate limiting por IP, header o token. El rate limiting por cuenta/email en login o recupero conviene implementarlo en el auth service: el identificador suele venir en el body y requiere lógica de dominio. ([KrakenD][14])
+
+---
+
+## Errores comunes
+
+1. **Centralizar autorización en el gateway.** El gateway verifica si una ruta es protegida o un rol global grueso; no resuelve ownership ni reglas de negocio.
+2. **Descartar Kong OSS.** Con un JWT emitido por el propio equipo es válido. La fricción aparece solo en OIDC/Firebase directo (OpenID Connect es Enterprise). ([Kong JWT][25], [Kong OIDC][8])
+3. **Implementar refresh token propio si el IdP ya resuelve la sesión larga.** Superficie de ataque innecesaria. ([Firebase][18])
+4. **Confiar únicamente en claims externas para reglas finas.** `admin=true` no valida "este recurso es de este usuario". ([Firebase][20])
+5. **Asumir revocación/disable instantáneos sobre tokens ya emitidos.** El gateway que valida offline por firma/JWKS no se entera automáticamente. ([Firebase][21])
+6. **Afirmar atributos de seguridad que no pueden demostrarse.** Si el reset o el hashing están delegados al proveedor, no inventar detalles técnicos sobre código que no controlan.
+7. **Asumir que la authz fina debe vivir exclusivamente en cada microservicio o, al revés, exclusivamente en el gateway.** La decisión puede centralizarse, pero necesita datos del dominio y un enforcement claro cerca del recurso protegido. ([OPA][32], [Keycloak Authz][33])
+
+---
+
+## Checklist para el ADR
+
+- ¿Dónde vive la identidad? ¿Quién emite el token que entra a la API?
+- ¿Qué valida el gateway y qué verifica cada microservicio?
+- ¿Cómo se renueva la sesión?
+- ¿Dónde se persiste el estado del usuario (bloqueo, roles, flags de negocio)?
+- ¿Qué garantías quedan delegadas al proveedor, cuáles implementadas por el equipo, y qué brechas quedan asumidas?
+- ¿Qué nivel de acoplamiento al proveedor aceptan y cuánto costaría migrar?
+
+---
+
+[1]: https://www.krakend.io/docs/authorization/jwt-validation/
+[2]: https://apisix.apache.org/docs/apisix/plugins/openid-connect/
+[3]: https://tyk.io/docs/5.7/tyk-open-source/
+[4]: https://developer.konghq.com/gateway/db-less-mode/
+[5]: https://doc.traefik.io/traefik/master/features/
+[6]: https://firebase.google.com/docs/auth
+[7]: https://tyk.io/docs/apim/open-source/installation
+[8]: https://developer.konghq.com/plugins/openid-connect/
+[9]: https://www.krakend.io/docs/design/backend-for-frontend/
+[10]: https://www.krakend.io/docs/deploying/docker/
+[11]: https://apisix.apache.org/docs/apisix/deployment-modes/
+[12]: https://doc.traefik.io/traefik/v3.4/middlewares/http/ratelimit/
+[13]: https://tyk.io/docs/api-management/gateway-config-tyk-oas
+[14]: https://www.krakend.io/docs/endpoints/rate-limit/
+[15]: https://apisix.apache.org/docs/apisix/plugins/limit-count/
+[16]: https://tyk.io/docs/5.0/basic-config-and-security/control-limit-traffic/rate-limiting/
+[17]: https://developer.konghq.com/plugins/rate-limiting/
+[18]: https://firebase.google.com/docs/auth/admin/manage-sessions
+[19]: https://firebase.google.com/docs/auth
+[20]: https://firebase.google.com/docs/auth/admin/custom-claims
+[21]: https://firebase.google.com/docs/auth/admin/verify-id-tokens
+[22]: https://firebase.google.com/docs/auth/admin/import-users
+[23]: https://firebase.google.com/docs/reference/rest/auth
+[24]: https://apisix.apache.org/docs/apisix/3.10/plugins/openid-connect/
+[25]: https://developer.konghq.com/plugins/jwt/
+[26]: https://apisix.apache.org/docs/apisix/installation-guide/
+[27]: https://developer.konghq.com/gateway/install/docker-read-only/
+[28]: https://doc.traefik.io/traefik/setup/docker/
+[29]: https://doc.traefik.io/traefik/v3.4/middlewares/http/forwardauth/
+[30]: https://clerk.com/docs/expo/getting-started/quickstart
+[31]: https://clerk.com/docs/guides/force-token-refresh
+[32]: https://www.openpolicyagent.org/docs/external-data
+[33]: https://www.keycloak.org/docs/latest/authorization_services/index.html
+[34]: https://www.oauth.com/oauth2-servers/the-resource-server/
+[35]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+[36]: https://docs.spring.io/spring-authorization-server/reference/overview.html
+[37]: https://fastapi.tiangolo.com/tutorial/security/oauth2-jwt/
+[38]: https://github.com/panva/node-oidc-provider
+[39]: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
+[40]: https://openid.net/specs/openid-connect-core-1_0.html

--- a/content/blog/2026-04-03-auth.md
+++ b/content/blog/2026-04-03-auth.md
@@ -10,17 +10,14 @@ tags:
 
 ## TL;DR
 
-
-| Cuándo | Opción | Trade-off principal |
-| :----- | :----- | :------------------ |
-| **Control total** | **Auth propia** | Más control y más garantías demostrables, pero también más diseño, operación y revisión. ([OWASP Passwords][35], [OWASP AuthN][39], [Spring Auth Server][36]) |
-| **Proxy simple** | **Traefik OSS + ForwardAuth** | Routing simple; la auth se delega a otro servicio. ([Traefik Features][5], [Traefik ForwardAuth][29], [Traefik Docker][28]) |
-| **BFF simple** | **KrakenD CE** | Declarativo, JWT/OIDC y pocas dependencias. ([KrakenD][1]) |
-| **Policies y cuotas** | **Tyk OSS** | Muy completo, pero con Redis como costo operativo. ([Tyk][3]) |
-| **JWT del equipo en gateway** | **Kong OSS** | Encaja con JWT propio; OIDC directo en OSS suma fricción. ([Kong DB-less][4], [Kong JWT][25], [Kong OIDC][8]) |
-| **Extensibilidad** | **Apache APISIX** | Muy flexible, pero con más configuración explícita. ([Apache APISIX][2]) |
-| **Delegar identidad** | **IdP externo + gateway** | Menos complejidad en login y sesión, pero más garantías delegadas al proveedor. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30]) |
-| **Token del equipo** | **IdP externo + JWT propio** | Desacopla a los servicios del IdP, pero agrega exchange, refresh y operación. ([OpenID Connect][40], [Firebase][21], [Clerk Token][31]) |
+| Cuándo                        | Opción                        | Trade-off principal                                                                                                                                           |
+| :---------------------------- | :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Control total**             | **Auth propia**               | Más control y más garantías demostrables, pero también más diseño, operación y revisión. ([OWASP Passwords][35], [OWASP AuthN][39], [Spring Auth Server][36]) |
+| **Proxy simple**              | **Traefik OSS + ForwardAuth** | Routing simple; la auth se delega a otro servicio. ([Traefik Features][5], [Traefik ForwardAuth][29], [Traefik Docker][28])                                   |
+| **BFF simple**                | **KrakenD CE**                | Declarativo, JWT/OIDC y pocas dependencias. ([KrakenD][1])                                                                                                    |
+| **Policies y cuotas**         | **Tyk OSS**                   | Muy completo, pero con Redis como costo operativo. ([Tyk][3])                                                                                                 |
+| **JWT del equipo en gateway** | **Kong OSS**                  | Encaja con JWT propio; OIDC directo en OSS suma fricción. ([Kong DB-less][4], [Kong JWT][25], [Kong OIDC][8])                                                 |
+| **Extensibilidad**            | **Apache APISIX**             | Muy flexible, pero con más configuración explícita. ([Apache APISIX][2])                                                                                      |
 
 ---
 
@@ -44,13 +41,13 @@ OIDC resuelve identidad/login. La authz fina puede apoyarse en claims o scopes, 
 
 ## Gateways y Proxies
 
-| Producto                      | Cuándo elegirlo                         | Modelo mental                                                                                  | Operación                                                             | Dependencias                                                          | OIDC / JWT externo                                                                            | Rate limiting                                                            |
-| :---------------------------- | :-------------------------------------- | :--------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
-| **KrakenD CE**                | Simplicidad + BFF sin extras            | Declarativo, BFF/agregación ([KrakenD][9])                                                     | Muy buena; Dockerfile inmutable ([KrakenD][10])                       | Sin DB/Redis ([KrakenD][10])                                          | Fit nativo; Firebase/Google explícito ([KrakenD][1])                                          | `max_rate` + `client_max_rate`, en memoria ([KrakenD][14])               |
-| **Apache APISIX**             | Máxima flexibilidad de plugins          | Gateway de plugins, cloud-native ([APISIX][2])                                                 | Standalone reduce ops, pero exige más config explícita ([APISIX][11]) | Sin etcd en Standalone ([APISIX][11])                                 | Plugin `openid-connect`; Google y otros IdP ([APISIX][2])                                     | `limit-count` (fixed window) + `limit-req` (leaky bucket) ([APISIX][15]) |
-| **Tyk OSS**                   | Rate limiting avanzado; se acepta Redis | _Batteries included_, fuerte en policies ([Tyk][3])                                            | Fácil de levantar, arrastra Redis ([Tyk][7])                          | Redis obligatorio ([Tyk][7])                                          | JWT + JWKS URIs; buen fit con IdP externo ([Tyk][13])                                         | API-level y Key-level ([Tyk][16])                                        |
-| **Traefik OSS + ForwardAuth** | Edge router liviano; auth delegada      | Application proxy; auth en servicio externo ([Traefik Features][5], [Traefik ForwardAuth][29]) | Muy buena; hot reload, labels/CRDs ([Traefik Docker][28])             | Sin DB; auth depende del servicio externo ([Traefik ForwardAuth][29]) | JWT/OIDC nativo solo en Hub; en OSS se delega por `ForwardAuth` ([Traefik Features][5])       | Token bucket con middleware `RateLimit` ([Traefik RateLimit][12])        |
-| **Kong OSS**                  | El equipo emite su propio JWT           | Plugin-based, muy flexible ([Kong][4])                                                         | DB-less simplifica bastante ([Kong][4])                               | Sin DB en modo DB-less ([Kong][4])                                    | JWT emitido por el equipo: OK. OIDC/Firebase directo: fricción (Enterprise) ([Kong JWT][25], [Kong OIDC][8]) | Local, cluster, Redis ([Kong][17])                                       |
+| Producto                      | Modelo mental                                                                                  | Operación                                                             | Dependencias                                                          | OIDC / JWT externo                                                                                           | Rate limiting                                                            |
+| :---------------------------- | :--------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
+| **KrakenD CE**                | Declarativo, BFF/agregación ([KrakenD][9])                                                     | Muy buena; Dockerfile inmutable ([KrakenD][10])                       | Sin DB/Redis ([KrakenD][10])                                          | Fit nativo; Firebase/Google explícito ([KrakenD][1])                                                         | `max_rate` + `client_max_rate`, en memoria ([KrakenD][14])               |
+| **Apache APISIX**             | Gateway de plugins, cloud-native ([APISIX][2])                                                 | Standalone reduce ops, pero exige más config explícita ([APISIX][11]) | Sin etcd en Standalone ([APISIX][11])                                 | Plugin `openid-connect`; Google y otros IdP ([APISIX][2])                                                    | `limit-count` (fixed window) + `limit-req` (leaky bucket) ([APISIX][15]) |
+| **Tyk OSS**                   | _Batteries included_, fuerte en policies ([Tyk][3])                                            | Fácil de levantar, arrastra Redis ([Tyk][7])                          | Redis obligatorio ([Tyk][7])                                          | JWT + JWKS URIs; buen fit con IdP externo ([Tyk][13])                                                        | API-level y Key-level ([Tyk][16])                                        |
+| **Traefik OSS + ForwardAuth** | Application proxy; auth en servicio externo ([Traefik Features][5], [Traefik ForwardAuth][29]) | Muy buena; hot reload, labels/CRDs ([Traefik Docker][28])             | Sin DB; auth depende del servicio externo ([Traefik ForwardAuth][29]) | JWT/OIDC nativo solo en Hub; en OSS se delega por `ForwardAuth` ([Traefik Features][5])                      | Token bucket con middleware `RateLimit` ([Traefik RateLimit][12])        |
+| **Kong OSS**                  | Plugin-based, muy flexible ([Kong][4])                                                         | DB-less simplifica bastante ([Kong][4])                               | Sin DB en modo DB-less ([Kong][4])                                    | JWT emitido por el equipo: OK. OIDC/Firebase directo: fricción (Enterprise) ([Kong JWT][25], [Kong OIDC][8]) | Local, cluster, Redis ([Kong][17])                                       |
 
 **Sin Kubernetes:** todas estas opciones pueden correrse con contenedores. ([KrakenD][10], [APISIX][26], [Tyk][3], [Kong Docker][27], [Traefik Docker][28])
 
@@ -75,9 +72,9 @@ El cliente mobile se autentica con un proveedor externo de identidad y usa ese t
 
 **Pros y contras**
 
-| Trade-off     | Detalle                                                                                                                                                                                                                     |
-| :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **A favor**   | Menor superficie a implementar; sesión larga y renovación ya resueltas; flujos de email/password y login federado disponibles según el proveedor elegido. ([Firebase][19], [Clerk Expo][30])                                |
+| Trade-off     | Detalle                                                                                                                                                                                                                                                             |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **A favor**   | Menor superficie a implementar; sesión larga y renovación ya resueltas; flujos de email/password y login federado disponibles según el proveedor elegido. ([Firebase][19], [Clerk Expo][30])                                                                        |
 | **En contra** | Parte de la lógica queda fuera del control del equipo. Según el proveedor, puede no haber evidencia documental suficiente para ciertas garantías duras; en Firebase, por ejemplo, no está verificable un TTL máximo de 1h para reset ni storage hasheado del token. |
 
 ### IdP externo + JWT propio
@@ -95,12 +92,46 @@ El equipo implementa su propia capa de identidad y sesión para la plataforma: r
 
 Eso no reemplaza el estado propio del dominio ni la capa de autorización: `blocked`, ownership, permisos finos y reglas de negocio siguen fuera de esta capa. También conviene distinguir una auth propia para la app de un authorization server OAuth/OIDC completo para terceros: lo segundo es bastante más ambicioso. Hoy, además, no implica necesariamente escribir todo desde cero; existen frameworks y librerías maduras como Spring Authorization Server, las herramientas de seguridad de FastAPI para OAuth2/JWT o `node-oidc-provider`. Aun así, la implementación, operación y seguridad siguen siendo responsabilidad del equipo. ([OWASP Passwords][35], [Spring Auth Server][36], [FastAPI Security][37], [node-oidc-provider][38])
 
-| Trade-off     | Detalle                                                                                                                                                   |
-| :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **A favor**   | Control total sobre identidad, sesiones y claims de plataforma. Muy buena opción si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías implementadas por ellos mismos. |
-| **A favor**   | Con librerías modernas, el volumen de código commodity puede ser bastante menor de lo que sugiere la intuición inicial.                                                                                   |
+| Trade-off     | Detalle                                                                                                                                                                                                                                                |
+| :------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A favor**   | Control total sobre identidad, sesiones y claims de plataforma. Muy buena opción si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías implementadas por ellos mismos.                                               |
+| **A favor**   | Con librerías modernas, el volumen de código commodity puede ser bastante menor de lo que sugiere la intuición inicial.                                                                                                                                |
 | **En contra** | El equipo pasa a ser responsable de cerrar bien autenticación, sesiones, recupero, almacenamiento seguro, revocación, auditoría y mitigaciones de abuso. Las librerías ayudan, pero no reemplazan diseño ni revisión de seguridad. ([OWASP AuthN][39]) |
-| **En contra** | Si además se quiere exponer un authorization server OAuth/OIDC completo y reutilizable para terceros, la complejidad sube respecto de una auth propia solo para la app.                                 |
+| **En contra** | Si además se quiere exponer un authorization server OAuth/OIDC completo y reutilizable para terceros, la complejidad sube respecto de una auth propia solo para la app.                                                                                |
+
+---
+
+## Opciones de IdP
+
+Además de elegir gateway, conviene decidir quién resuelve identidad y sesión. En esta guía aparecen tres familias:
+
+- **Plataformas gestionadas**: Clerk, Firebase Authentication, Supabase Auth, Auth0.
+- **Plataformas self-hosted**: Keycloak.
+- **Auth propia**: implementada por el equipo.
+
+Todas pueden encajar con el patrón `IdP + gateway`: el proveedor resuelve login, registro, sesión y recuperación; el gateway valida el token; y la autorización fina junto con el estado real del dominio siguen fuera del IdP.
+
+{{< youtube 5KChrGWFcpk >}}
+
+### IdP externo + gateway
+
+Este patrón conviene cuando el objetivo no es construir identidad desde cero, sino llegar rápido a una API protegida con login razonable, sesión larga y validación de tokens.
+
+| Opción                      | Tipo                                           | Qué simplifica                                                                                                                                                                                                                                                  | Trade-off principal                                                                                                                                                                                |
+| :-------------------------- | :--------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Clerk**                   | Plataforma de auth gestionada                  | UIs prearmadas para `sign-in` y gestión de perfil; integración rápida; plan gratis con hasta `50.000` Monthly Retained Users. ([Clerk Pricing][41], [Clerk SignIn][42], [Clerk UserProfile][43])                                                                | Muy baja fricción, pero servicio cerrado y mayor dependencia del proveedor.                                                                                                                        |
+| **Firebase Authentication** | Auth gestionada, muy común en mobile           | Email/password, reset por email, providers federados y UI prearmada. En el upgrade a Identity Platform agrega MFA, SAML y generic OIDC; ahí también aparecen el límite de `3.000` DAUs en Spark y el tier sin costo de `50.000` MAUs en Blaze. ([Firebase][19]) | Muy práctico y bien documentado, pero algunas garantías finas quedan delegadas al proveedor.                                                                                                       |
+| **Supabase Auth**           | Auth gestionada integrada a plataforma backend | Password, magic link, OTP, social login y SSO; `50.000` MAUs en Free; buen fit si el equipo también quiere DB, storage y APIs en la misma plataforma. ([Supabase Auth][44], [Supabase Billing][45])                                                             | Muy cómodo, pero mete dependencia de plataforma más amplia, no solo de identidad.                                                                                                                  |
+| **Auth0**                   | Plataforma de identidad más enterprise         | Hasta `25.000` MAUs en Free; passwordless, social login, custom domain y una enterprise connection. ([Auth0 Pricing][46], [Auth0 Custom Domains][47], [Auth0 Passwordless][48])                                                                                 | Muy completo, pero puede sentirse más pesado que otras opciones de esta guía.                                                                                                                      |
+| **Keycloak**                | IdP self-hosted / authorization server         | OIDC, OAuth2 y SAML; consola admin centralizada; federation y Authorization Services. ([Keycloak][49], [Keycloak Authz][33])                                                                                                                                    | Mucho resuelto sin escribir auth propia, pero hay que operarlo: contenedor, DB relacional y configuración propia del servicio. ([Keycloak Container][50], [Keycloak DB][51], [Keycloak Admin][52]) |
+
+### Cuándo conviene
+
+- **Si el foco está en llegar rápido a login, sesión y recuperación**, un IdP externo reduce bastante la superficie de implementación.
+- **Si se quiere más control sin implementar auth propia**, Keycloak resuelve mucho, pero agrega operación.
+- **Si hay que demostrar garantías muy específicas** sobre reset, revocación, hashing o storage del token, conviene distinguir con cuidado entre controles propios, self-hosted y delegados al proveedor.
+
+Ninguna de estas plataformas reemplaza al gateway, a la DB propia del dominio ni a la autorización fina. En otras palabras: **identidad y sesión pueden delegarse; autorización fina y enforcement final, no**. ([OAuth Resource Server][34], [OPA][32], [Keycloak Authz][33])
 
 ---
 
@@ -128,14 +159,14 @@ Si se exige BCrypt u otro algoritmo adaptativo: las contraseñas que viven en Fi
 
 | Responsabilidad                           | ¿Pasa por el gateway?        | Dónde se implementa                                 |
 | :---------------------------------------- | :--------------------------- | :-------------------------------------------------- |
-| Login federado con Google (optativo)      | No (valida el token después) | Proveedor de identidad                              |
-| Login con email/password                  | No                           | IdP o auth service propio                           |
-| Registro con email/password               | No                           | IdP o auth service propio                           |
-| Recupero de contraseña                    | No                           | IdP o auth service propio                           |
-| Hash de contraseñas (ej. BCrypt o scrypt) | No                           | Delegado al IdP o auth service propio               |
-| Reglas mínimas de contraseña              | No                           | Depende del approach de auth elegido                |
-| Renovación de sesión                      | No                           | Depende del approach de auth elegido                |
-| Emisión del token de API                  | No (solo valida)             | IdP o auth service                                  |
+| Login federado con Google (optativo)      | No (valida el token después) | IdP externo                                         |
+| Login con email/password                  | No                           | IdP externo o auth propia                           |
+| Registro con email/password               | No                           | IdP externo o auth propia                           |
+| Recupero de contraseña                    | No                           | IdP externo o auth propia                           |
+| Hash de contraseñas (ej. BCrypt o scrypt) | No                           | Delegado al IdP o resuelto por auth propia          |
+| Reglas mínimas de contraseña              | No                           | Depende de la opción de identidad elegida           |
+| Renovación de sesión                      | No                           | Depende de la opción de identidad elegida           |
+| Emisión del token de API                  | No (solo valida)             | IdP o auth service propio                           |
 | Validación del token de API               | Sí                           | Gateway                                             |
 | Decisión de autorización fina             | No                           | Servicios de dominio o capa central de autorización |
 | Rate limiting por IP                      | Sí                           | Gateway                                             |
@@ -215,3 +246,15 @@ Si se exige BCrypt u otro algoritmo adaptativo: las contraseñas que viven en Fi
 [38]: https://github.com/panva/node-oidc-provider
 [39]: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
 [40]: https://openid.net/specs/openid-connect-core-1_0.html
+[41]: https://clerk.com/pricing
+[42]: https://clerk.com/docs/reference/components/authentication/sign-in
+[43]: https://clerk.com/docs/reference/components/user/user-profile
+[44]: https://supabase.com/docs/guides/auth
+[45]: https://supabase.com/docs/guides/platform/billing-on-supabase
+[46]: https://auth0.com/pricing
+[47]: https://auth0.com/docs/customize/custom-domains
+[48]: https://auth0.com/docs/authenticate/passwordless
+[49]: https://www.keycloak.org/
+[50]: https://www.keycloak.org/server/containers
+[51]: https://www.keycloak.org/server/db
+[52]: https://www.keycloak.org/docs/latest/server_admin/

--- a/content/blog/2026-04-03-auth.md
+++ b/content/blog/2026-04-03-auth.md
@@ -1,224 +1,367 @@
 ---
 date: "2026-04-03T00:00:00Z"
 title: "Guía de cátedra 2026: API Gateway + Auth/Authz"
-description: "Guía de cátedra sobre autenticación, autorización y API Gateway para 2026: auth propia, IdP externos, manejo de sesión y criterios para elegir gateway."
+description: "Guía de cátedra sobre auth distribuida en microservicios: identidades, puntos donde cambia la confianza, propagación de identidad y criterios para elegir implementación."
 tags:
   - cloud-computing
   - microservicios
   - 2026-1C
 ---
 
-## TL;DR
+**En corto**
 
-| Cuándo                        | Opción                        | Trade-off principal                                                                                                                                           |
-| :---------------------------- | :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Control total**             | **Auth propia**               | Más control y más garantías demostrables, pero también más diseño, operación y revisión. ([OWASP Passwords][35], [OWASP AuthN][39], [Spring Auth Server][36]) |
-| **Proxy simple**              | **Traefik OSS + ForwardAuth** | Routing simple; la auth se delega a otro servicio. ([Traefik Features][5], [Traefik ForwardAuth][29], [Traefik Docker][28])                                   |
-| **BFF simple**                | **KrakenD CE**                | Declarativo, JWT/OIDC y pocas dependencias. ([KrakenD][1])                                                                                                    |
-| **Policies y cuotas**         | **Tyk OSS**                   | Muy completo, pero con Redis como costo operativo. ([Tyk][3])                                                                                                 |
-| **JWT del equipo en gateway** | **Kong OSS**                  | Encaja con JWT propio; OIDC directo en OSS suma fricción. ([Kong DB-less][4], [Kong JWT][25], [Kong OIDC][8])                                                 |
-| **Extensibilidad**            | **Apache APISIX**             | Muy flexible, pero con más configuración explícita. ([Apache APISIX][2])                                                                                      |
+- Elegí `auth propia` si identidad, sesión y garantías demostrables forman parte del problema que el equipo quiere resolver.
+- Elegí `IdP externo` si querés delegar login y sesión, pero asumí desde el día uno que el dominio igual tendrá que resolver bloqueo de usuarios, ownership y `fine-grained authorization`.
+- Referencias rápidas: [gateways](#apéndice-gateways) e [IdP externos](#apéndice-idp-externos).
 
----
+## El problema
 
-## Responsabilidades
+En un monolito, login, sesión y permisos suelen sentirse como un único problema porque todo vive en la misma aplicación y comparte estado. En microservicios no: un mismo request cruza identidad, borde y dominio. Por eso **no alcanza con "poner auth en el gateway"**. ([Microservices Auth Intro][58], [Microsoft APIM Auth][60])
 
-Más allá del stack elegido, conviene separar el sistema en cuatro capas. Cada una resuelve un problema distinto y no debería invadir por completo a las demás.
+Por ejemplo, tomemos esta request: `POST /orders/123/cancel`.
 
-**Identidad y sesión.** La resuelve un proveedor de identidad o una plataforma de auth, como Firebase Auth, Clerk o un servicio propio. Esta capa se ocupa de registro, login, recuperación de credenciales y manejo de sesión.
+- **Identidad.** El usuario inicia sesión contra un `IdP` o `auth service` y obtiene una sesión y un bearer token.
+- **Borde.** El cliente llama a la API de entrada y el `gateway` o `BFF` (`backend-for-frontend`) decide si el request supera la primera barrera.
+- **Dominio.** El servicio de `orders` consulta ownership, estado del pedido, usuario bloqueado y rol efectivo. Recién ahí decide si la operación está permitida.
 
-**Gateway / Proxy.** Valida el token, o delega esa validación, cierra rutas, aplica rate limiting grueso y, cuando corresponde, hace agregación tipo BFF. Muchos además traen soporte o plugins para JWT/OIDC y pueden resolver authz gruesa basada en scopes, claims o integración con un servicio externo.
+El borde autentica y filtra; el dominio autoriza de verdad. En un sistema distribuido no participa una sola identidad, la confianza cambia varias veces y la decisión real necesita datos que no viven todos en el mismo lugar. ([Microservices Auth Intro][58], [Google Identity Propagation][61], [NIST API Protection][65])
 
-**Autorización.** Define si un usuario puede o no hacer una acción concreta. Esa decisión puede vivir dentro de cada servicio o centralizarse en un auth service o policy engine. Lo importante es que use reglas reales del dominio, no solo claims del token. ([OPA][32], [Keycloak Authz][33])
+Un segundo caso muestra otra clase de regla: `POST /admin/users/123/block`. Ahí ya no manda ownership, sino rol administrativo, alcance sobre la organización o tenant y trazabilidad de la acción. El token puede traer contexto inicial, pero la decisión real sigue dependiendo de política y estado actual.
 
-**Servicios de dominio.** Son el último punto de enforcement. Aunque el gateway filtre y el token sea válido, acá se decide finalmente sobre recursos, ownership, bloqueos, flags de negocio y cualquier regla que dependa del estado real del sistema.
+```mermaid
+flowchart LR
+    Client([Cliente])
+    IdP([IdP])
+    DOM[(Estado actual del dominio)]
 
-OIDC resuelve identidad/login. La authz fina puede apoyarse en claims o scopes, pero no debería depender solo de eso ni solo del gateway. ([OAuth Resource Server][34])
+    subgraph Borde
+        GW["gateway o BFF<br/>PEP de borde"]
+        TVL["validación de token"]
+    end
+
+    subgraph Plataforma
+        AL["Authorization layer<br/>(opcional, PDP)"]
+        DS["Domain service<br/>PEP final"]
+    end
+
+    Client -->|"bearer token"| GW
+    GW -->|"firma / exp / formato"| TVL
+    TVL -->|"JWKS / introspection"| IdP
+    GW -->|"request + contexto"| AL
+    AL -->|"blocked / roles"| DOM
+    AL -->|"allow preliminar"| DS
+    DS -->|"ownership / estado del recurso"| DOM
+    DS -->|"allow / deny"| GW
+    GW --> Client
+```
 
 {{< youtube iX8g4LqF8p8 >}}
 
 ---
 
-## Gateways y Proxies
+## Preguntas clave
 
-| Producto                      | Modelo mental                                                                                  | Operación                                                             | Dependencias                                                          | OIDC / JWT externo                                                                                           | Rate limiting                                                            |
-| :---------------------------- | :--------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
-| **Traefik OSS + ForwardAuth** | Application proxy; auth en servicio externo ([Traefik Features][5], [Traefik ForwardAuth][29]) | Muy buena; hot reload, labels/CRDs ([Traefik Docker][28])             | Sin DB; auth depende del servicio externo ([Traefik ForwardAuth][29]) | JWT/OIDC nativo solo en Hub; en OSS se delega por `ForwardAuth` ([Traefik Features][5])                      | Token bucket con middleware `RateLimit` ([Traefik RateLimit][12])        |
-| **KrakenD CE**                | Declarativo, BFF/agregación ([KrakenD][9])                                                     | Muy buena; Dockerfile inmutable ([KrakenD][10])                       | Sin DB/Redis ([KrakenD][10])                                          | Fit nativo; Firebase/Google explícito ([KrakenD][1])                                                         | `max_rate` + `client_max_rate`, en memoria ([KrakenD][14])               |
-| **Tyk OSS**                   | _Batteries included_, fuerte en policies ([Tyk][3])                                            | Fácil de levantar, arrastra Redis ([Tyk][7])                          | Redis obligatorio ([Tyk][7])                                          | JWT + JWKS URIs; buen fit con IdP externo ([Tyk][13])                                                        | API-level y Key-level ([Tyk][16])                                        |
-| **Kong OSS**                  | Plugin-based, muy flexible ([Kong][4])                                                         | DB-less simplifica bastante ([Kong][4])                               | Sin DB en modo DB-less ([Kong][4])                                    | JWT emitido por el equipo: OK. OIDC/Firebase directo: fricción (Enterprise) ([Kong JWT][25], [Kong OIDC][8]) | Local, cluster, Redis ([Kong][17])                                       |
-| **Apache APISIX**             | Gateway de plugins, cloud-native ([APISIX][2])                                                 | Standalone reduce ops, pero exige más config explícita ([APISIX][11]) | Sin etcd en Standalone ([APISIX][11])                                 | Plugin `openid-connect`; Google y otros IdP ([APISIX][2])                                                    | `limit-count` (fixed window) + `limit-req` (leaky bucket) ([APISIX][15]) |
-
-**Sin Kubernetes:** todas estas opciones pueden correrse con contenedores. ([KrakenD][10], [APISIX][26], [Tyk][3], [Kong Docker][27], [Traefik Docker][28])
+1. ¿Qué identidades participan en este request?
+2. ¿Dónde cambia la confianza dentro del sistema?
+3. ¿Cómo se propaga la identidad hasta el servicio que decide?
+4. ¿Quién toma la decisión de autorización real?
+5. ¿Qué datos necesita esa decisión y quién es dueño de esos datos?
+6. ¿Qué queda en el token y qué obliga a consultar el estado actual del dominio?
 
 ---
 
-## Identidad y sesión
+## Qué resuelve cada capa
 
-La decisión principal no es Firebase sí o no, sino `IdP externo` versus `auth propia`. La elección pasa por control, responsabilidades operativas, evidencia de garantías de seguridad, costo de migración y tiempo de implementación. En esta guía, Firebase aparece como ejemplo frecuente, pero el mismo patrón aplica a Clerk u otros proveedores OIDC equivalentes. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30])
+| Capa                    | Resuelve                                          | No resuelve                                       |
+| :---------------------- | :------------------------------------------------ | :------------------------------------------------ |
+| **IdP / auth service**  | login, sesión, recupero y emisión de token        | permisos reales de dominio                        |
+| **gateway / BFF**       | validación inicial, rate limiting y filtro grueso | ownership, bloqueo de usuarios, reglas de negocio |
+| **Servicio de dominio** | autorización real sobre el recurso                | login o manejo de sesión                          |
+| **Datos de dominio**    | estado real: roles efectivos, ownership, flags    | enforcement por sí solos                          |
 
-**Regla de decisión**
+**Vocabulario mínimo**
 
-Un `IdP externo` no queda legitimado solo por ahorrar tiempo. Solo es defendible si el equipo puede explicar qué requisitos cubre el proveedor, cuáles siguen bajo responsabilidad propia y con qué evidencia va a sostener esa decisión ante la cátedra. Si esa defensa no puede hacerse con precisión, corresponde `auth propia`.
+- `AuthN`: verificar quién es.
+- `AuthZ`: decidir qué puede hacer sobre un recurso.
+- `BFF`: `backend-for-frontend`; una capa backend pensada para una app o canal específico.
+- `Claim`: dato portable dentro del token.
+- `Scope`: permiso amplio, útil para filtros iniciales.
+- `Coarse-grained authorization`: “¿en principio este request podría pasar?”
+- `Fine-grained authorization`: “¿esta persona puede hacer esto, sobre este recurso, ahora?” ([OAuth Resource Server][34], [OPA][32], [Keycloak Authz][33], [Curity Claims][67])
 
-### Auth propia
+Si la autorización empieza a repetirse o a cruzar muchos servicios, puede aparecer una `Authorization Layer` o policy engine. Ahí `PDP` decide y `PEP` hace cumplir. Conviene pensarlo como una opción de madurez, no como punto de partida. ([OPA][32], [Keycloak Authz][33])
 
-El equipo implementa su propia capa de identidad y sesión para la plataforma: registro, login, hash de contraseñas, recupero, refresh token, emisión de JWT y, si hace falta, claims o roles globales para la API.
+Si necesitás la versión exhaustiva de esta tabla, está en el [apéndice de matriz operativa](#apendice-matriz-operativa).
 
-Eso no reemplaza el estado propio del dominio ni la capa de autorización: `blocked`, ownership, permisos finos y reglas de negocio siguen fuera de esta capa. También conviene distinguir una auth propia para la app de un authorization server OAuth/OIDC completo para terceros: lo segundo es bastante más ambicioso.
-
-Hoy, además, no implica necesariamente escribir todo desde cero; existen frameworks y librerías maduras como Spring Authorization Server, las herramientas de seguridad de FastAPI para OAuth2/JWT o `node-oidc-provider`. Aun así, la implementación, operación y seguridad siguen siendo responsabilidad del equipo. ([OWASP Passwords][35], [Spring Auth Server][36], [FastAPI Security][37], [node-oidc-provider][38])
-
-| Trade-off     | Detalle                                                                                                                                                                                                                                                |
-| :------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **A favor**   | Control total sobre identidad, sesiones y claims de plataforma. Muy buena opción si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías implementadas por ellos mismos.                                               |
-| **A favor**   | Con librerías modernas, el volumen de código commodity puede ser bastante menor de lo que sugiere la intuición inicial.                                                                                                                                |
-| **En contra** | El equipo pasa a ser responsable de cerrar bien autenticación, sesiones, recupero, almacenamiento seguro, revocación, auditoría y mitigaciones de abuso. Las librerías ayudan, pero no reemplazan diseño ni revisión de seguridad. ([OWASP AuthN][39]) |
-| **En contra** | Si además se quiere exponer un authorization server OAuth/OIDC completo y reutilizable para terceros, la complejidad sube respecto de una auth propia solo para la app.                                                                                |
+Hasta acá separamos responsabilidades. El paso siguiente es entender quién actúa en cada tramo del request y dónde cambia la confianza.
 
 ---
 
-### IdP externo + gateway
+## Identidades y confianza
 
-El cliente mobile se autentica con un proveedor externo de identidad y usa ese token directamente contra el gateway. Firebase aparece acá solo como ejemplo frecuente, no como caso rector del documento. ([OpenID Connect][40], [Firebase][19], [Clerk Expo][30])
+En auth distribuida no participa solo el usuario final. También existen el cliente, el `BFF`, el `gateway` y los servicios internos que se llaman entre sí.
 
-**Flujo**
+Conviene distinguir explícitamente entre la autenticación y autorización del servicio llamador y la del usuario final. Esa diferencia importa porque un request puede transportar al mismo tiempo quién inició la acción y qué componente la está ejecutando en ese hop. ([NIST API Protection][65])
 
-1. El cliente autentica con un proveedor externo compatible con OIDC, por ejemplo Firebase Auth, Clerk u otro IdP equivalente. ([OpenID Connect][40], [Firebase][6], [Clerk Expo][30])
-2. El proveedor entrega el token de identidad o sesión según el flujo elegido.
-3. El cliente manda ese token al gateway.
-4. El gateway valida el token o delega la validación al componente correspondiente.
-5. El backend o la capa de autorización verifica `blocked`, `roles`, ownership y reglas de negocio contra estado confiable del dominio.
-6. Cuando el token vence, el cliente renueva la sesión según el mecanismo del proveedor o del auth service.
+En hops internos puede importar no solo la identidad del usuario, sino también la identidad del servicio que ejecuta la acción. `User identity` y `service identity` no son lo mismo, y conviene no mezclarlas.
 
-**Pros y contras**
+Los puntos que más conviene marcar en el diseño son siempre los mismos: login, emisión del primer token, entrada por `gateway` o `BFF`, hops inter-servicio y cualquier `token exchange` u on-behalf-of flow. El diagrama de identidad y acceso tiene que mostrar dónde se emiten tokens, dónde cambia la confianza y dónde aparecen esos flujos. No alcanza con saber quién inició el request; también importa qué componente lo ejecuta en cada hop y bajo qué relación de confianza. ([Azure Design Diagrams][66], [NIST API Protection][65])
 
-| Trade-off     | Detalle                                                                                                                                                                                                                                                             |
-| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **A favor**   | Menor superficie a implementar; sesión larga y renovación ya resueltas; flujos de email/password y login federado disponibles según el proveedor elegido. ([Firebase][19], [Clerk Expo][30])                                                                        |
-| **En contra** | Parte de la lógica queda fuera del control del equipo. Según el proveedor, puede no haber evidencia documental suficiente para ciertas garantías duras; en Firebase, por ejemplo, no está verificable un TTL máximo de 1h para reset ni storage hasheado del token. |
+**Propagación de identidad**
 
-### IdP externo + JWT propio
+Con ese mapa, la siguiente decisión ya no es quién participa sino cómo llega la identidad hasta el servicio que protege el recurso.
 
-El cliente sigue logueando con un proveedor externo, pero el auth service valida ese token y emite un JWT propio de la plataforma, es decir, un token emitido por el equipo para su API. El gateway valida ese token propio.
+| Diseño                              | Qué viaja hasta backend        | Ventaja principal                                              | Costo principal                                   |
+| :---------------------------------- | :----------------------------- | :------------------------------------------------------------- | :------------------------------------------------ |
+| **External token propagation**      | el token emitido por el `IdP`  | contexto end-to-end, mejor auditoría, menos moving parts       | más acoplamiento al proveedor                     |
+| **Token exchange / internal token** | un token interno de plataforma | desacopla al `IdP` y normaliza credenciales dentro del sistema | más emisión, renovación y superficie de seguridad |
 
-| Trade-off     | Detalle                                                                                                                                                                                                                                            |
-| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **A favor**   | Claims completamente propias; mayor independencia del IdP; cambiar de proveedor afecta menos a los servicios.                                                                                                                                      |
-| **En contra** | Hay que resolver la renovación (refresh token propio o re-exchange contra el proveedor externo); más superficie de implementación. Conviene solo si el equipo puede justificar técnicamente el valor que gana. ([Firebase][21], [Clerk Token][31]) |
+**External token propagation**
 
-## Opciones de IdP
+El token emitido por el proveedor cruza el borde y sigue viaje hacia backend. Propagar el `security context` end-to-end mejora la auditoría, evita cuentas genéricas privilegiadas y habilita decisiones más ricas en backend. ([Google Identity Propagation][61], [Microservices JWT Authz][68])
 
-Además de elegir gateway, conviene decidir quién resuelve identidad y sesión. En esta guía aparecen tres familias:
+```mermaid
+flowchart LR
+    subgraph A["External token propagation"]
+        direction LR
+        IdP1[IdP] -->|token del IdP| Client1[cliente]
+        Client1 -->|mismo token| Edge1[gateway o BFF]
+        Edge1 -->|mismo token| Svc1[servicio]
+    end
+```
 
-- **Plataformas gestionadas**: Clerk, Firebase Authentication, Supabase Auth, Auth0.
-- **Plataformas self-hosted**: Keycloak.
-- **Auth propia**: implementada por el equipo.
+**Token exchange / internal token**
 
-Todas pueden encajar con el patrón `IdP + gateway`: el proveedor resuelve login, registro, sesión y recuperación; el gateway valida el token; y la autorización fina junto con el estado real del dominio siguen fuera del IdP.
+El borde o un `auth service` valida el token externo y lo intercambia por uno interno. Hay un mecanismo estándar para ese intercambio. También puede servir para cambiar de credencial cuando entra el request a la plataforma, desacoplar a los servicios del proveedor externo y fijar una semántica propia de plataforma. El costo es más serio: claves, expiración, renovación y más decisiones de seguridad. ([Token Exchange][54], [NIST API Protection][65])
+
+```mermaid
+flowchart LR
+    subgraph B["Token exchange / internal token"]
+        direction LR
+        IdP2[IdP] -->|token del IdP| Client2[cliente]
+        Client2 -->|token externo| Edge2[gateway o auth service]
+        Edge2 -->|valida y reemite| Internal[token interno]
+        Internal --> Svc2[servicio]
+    end
+```
+
+En la práctica, esta decisión define cuánto contexto viaja end-to-end y cuánto costo operativo asumís para desacoplar la plataforma del proveedor.
+
+---
+
+## Autenticación en el borde
+
+| Patrón                                     | Qué hace el borde                                        | Cuándo encaja                                                   | Límite principal                  |
+| :----------------------------------------- | :------------------------------------------------------- | :-------------------------------------------------------------- | :-------------------------------- |
+| **Validación local de JWT/JWKS**           | verifica firma y `claims` localmente                     | access token `JWT` y baja latencia                              | no ve estado fresco por sí solo   |
+| **Introspection remota**                   | consulta online si el token está activo                  | tokens opacos o necesidad de validación revocation-aware        | más latencia y dependencia de red |
+| **Delegación a servicio externo de auth**  | pregunta a un `auth service` propio                      | cuando el gateway OSS no resuelve nativamente lo que hace falta | otro hop y contrato propio        |
+| **Login/sesión mediado por gateway o BFF** | el borde participa más directamente del flujo OAuth/OIDC | apps web o BFFs que concentran sesión                           | más moving parts en el borde      |
+
+### Validación local de `JWT/JWKS`
+
+Elegila cuando priorizás latencia y el access token ya trae suficiente contexto inicial. El patrón clásico del resource server: firma, expiración, formato y `claims` básicos se verifican localmente. Si el access token es un `JWT`, existe un perfil interoperable para ese caso. Lo que no resuelve por sí solo es revocación, usuario bloqueado, rol efectivo, ownership o reglas de negocio. ([OAuth Resource Server][34], [JWT Access Token Profile][55])
+
+### Introspection remota
+
+Conviene cuando necesitás estado más fresco o trabajás con tokens opacos. El borde le pregunta online al authorization server si el token está activo. Ese camino tiene un estándar claro, pero aumenta la dependencia de red y disponibilidad. ([Token Introspection][53])
+
+### External auth
+
+Encaja cuando querés unificar lógica común sin meterla entera en el gateway. Un patrón común es delegar la decisión inicial a un endpoint externo, por ejemplo con `ext_authz` o `ForwardAuth`. Es útil cuando el gateway OSS no trae capacidades nativas suficientes o cuando el equipo quiere concentrar autenticación común en un servicio propio. ([Envoy ext_authz][62], [Traefik ForwardAuth][29])
+
+### gateway/BFF como cliente `OIDC`
+
+Tiene sentido cuando el borde también administra login o sesión de una app web. El borde participa más directamente del flujo de login o sesión y puede actuar como cliente OAuth/OIDC o `Relying Party`. Conviene especialmente en aplicaciones web y BFFs. No es sinónimo de validar un bearer token ya emitido. ([OpenID Connect][40], [API Gateway Pattern][59])
+
+Si querés bajar estos patrones a herramientas concretas, fijate el [apéndice de gateways](#apendice-gateways).
+
+Hasta acá definiste qué contexto viaja y cómo lo valida el borde. Falta lo más difícil: con qué datos decide el dominio.
+
+---
+
+## Autorización distribuida
+
+La responsabilidad primaria de autorización sigue estando en los servicios, porque son quienes protegen recursos concretos y quienes pueden acceder a datos de aplicación. En el borde solo ves el request; en el dominio ves el recurso, su estado y sus relaciones. ([Microservices JWT Authz][68])
+
+**Ojo con esto.** Un bearer token válido no prueba que una operación esté permitida. Prueba identidad y contexto de acceso. El permiso real puede depender de ownership, estado del recurso, tenant, suspensión del usuario o reglas de negocio.
+
+### Claims y scopes
+
+Un `claim` es un dato que viene dentro del token. Un `scope` es un permiso de alto nivel que también puede viajar en el token y suele expresarse como una cadena tipo `orders.read`. `claims` y `scopes` sirven para `coarse-grained authorization`. Funcionan bien cuando el dato es chico, estable y suficientemente genérico para viajar en el token:
+
+- `scope=payments.read`
+- `role=admin`
+- `aud=orders-api`
+
+<details>
+<summary> Esto es un ejemplo de access token</summary>
+
+```json
+{
+  "iss": "https://iam.example.com",
+  "sub": "user_123",
+  "aud": "orders-api",
+  "exp": 1765197600,
+  "iat": 1765194000,
+  "nbf": 1765194000,
+  "jti": "01HT8M9Y7K4Q2R6W8X1Z3A5B7C",
+  "client_id": "mobile-app",
+  "scope": "orders.read orders.cancel",
+  "role": "customer",
+  "user_id": 123,
+  "tenant_id": "tenant_42",
+  "organization_id": "org_7",
+  "amr": ["pwd", "mfa"],
+  "delegation_id": "9c4b4d1a-6a66-4e56-8f76-2c5031d9a41b"
+}
+```
+
+</details>
+
+No todos los tokens llevan todos esos campos, y los nombres cambian según el `IdP` o el diseño de la plataforma. `tenant_id`, `organization_id`, `amr` o `delegation_id` son ejemplos opcionales. Lo importante no es memorizar nombres, sino distinguir qué conviene llevar en el token y qué sigue dependiendo del estado actual del dominio.
+
+Los `claims` y `scopes` sirven para filtros iniciales y para parte de la autorización, pero no para todo. Cuando la autorización es muy cambiante o depende de permisos de negocio volátiles, el token por sí solo no alcanza. ([Curity Claims][67], [Microservices JWT Authz][68])
+
+### Datos para decidir
+
+Un `isAllowed(user, operation, resource)` necesita más que identidad. Para tomar esa decisión conviene separar tres categorías. ([Microservices JWT Authz][68])
+
+- **built-in**: identidad y roles que vienen del token;
+- **local**: datos del propio servicio;
+- **remote**: datos que pertenecen a otros servicios.
+
+Ahí aparece la parte realmente distribuida del problema. Ownership, estado de bloqueo, relaciones, flags y permisos volátiles obligan a consultar el estado actual del dominio o a mantener una estrategia explícita para obtener esos datos. Conviene usar `claims` estables para filtrar y combinarlos con business permissions volátiles cuando la regla real depende del dominio. ([Curity Claims][67], [Microservices JWT Authz][68], [OPA][32], [Keycloak Authz][33])
+
+---
+
+## Quién resuelve identidad
+
+Antes de discutir Firebase, Clerk o Keycloak, hay que entender qué están eligiendo: quién resuelve login, sesión y emisión de tokens. Eso no incluye `fine-grained authorization` de negocio, que sigue siendo responsabilidad propia independientemente del proveedor.
 
 {{< youtube 5KChrGWFcpk >}}
 
-### IdP externos
+También conviene separar tres piezas que suelen mezclarse:
 
-Este patrón conviene cuando el objetivo no es construir identidad desde cero, sino llegar rápido a una API protegida con login razonable, sesión larga y validación de tokens.
+- `ID token`: le dice al cliente quién es el usuario.
+- `access token`: sirve para llamar APIs.
+- `refresh token`: renueva la sesión sin volver a autenticarse.
 
-| Opción                      | Tipo                                           | Qué simplifica                                                                                                                                                                                                                                                  | Trade-off principal                                                                                                                                                                                |
-| :-------------------------- | :--------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Clerk**                   | Plataforma de auth gestionada                  | UIs prearmadas para `sign-in` y gestión de perfil; integración rápida; plan gratis con hasta `50.000` Monthly Retained Users. ([Clerk Pricing][41], [Clerk SignIn][42], [Clerk UserProfile][43])                                                                | Muy baja fricción, pero servicio cerrado y mayor dependencia del proveedor.                                                                                                                        |
-| **Firebase Authentication** | Auth gestionada, muy común en mobile           | Email/password, reset por email, providers federados y UI prearmada. En el upgrade a Identity Platform agrega MFA, SAML y generic OIDC; ahí también aparecen el límite de `3.000` DAUs en Spark y el tier sin costo de `50.000` MAUs en Blaze. ([Firebase][19]) | Muy práctico y bien documentado, pero algunas garantías finas quedan delegadas al proveedor.                                                                                                       |
-| **Supabase Auth**           | Auth gestionada integrada a plataforma backend | Password, magic link, OTP, social login y SSO; `50.000` MAUs en Free; buen fit si el equipo también quiere DB, storage y APIs en la misma plataforma. ([Supabase Auth][44], [Supabase Billing][45])                                                             | Muy cómodo, pero mete dependencia de plataforma más amplia, no solo de identidad.                                                                                                                  |
-| **Auth0**                   | Plataforma de identidad más enterprise         | Hasta `25.000` MAUs en Free; passwordless, social login, custom domain y una enterprise connection. ([Auth0 Pricing][46], [Auth0 Custom Domains][47], [Auth0 Passwordless][48])                                                                                 | Muy completo, pero puede sentirse más pesado que otras opciones de esta guía.                                                                                                                      |
-| **Keycloak**                | IdP self-hosted / authorization server         | OIDC, OAuth2 y SAML; consola admin centralizada; federation y Authorization Services. ([Keycloak][49], [Keycloak Authz][33])                                                                                                                                    | Mucho resuelto sin escribir auth propia, pero hay que operarlo: contenedor, DB relacional y configuración propia del servicio. ([Keycloak Container][50], [Keycloak DB][51], [Keycloak Admin][52]) |
+Un error clásico es usar el `ID token` como si fuera el token de autorización de la API. Para la API, el token relevante suele ser el `access token`. ([OpenID Connect][40], [OAuth Refresh Tokens][70], [OAuth Resource Server][34])
 
-Ninguna de estas plataformas reemplaza al gateway, a la DB propia del dominio ni a la autorización fina. En otras palabras: **identidad y sesión pueden delegarse; autorización fina y enforcement final, no**. ([OAuth Resource Server][34], [OPA][32], [Keycloak Authz][33])
+Si querés comparar proveedores concretos de identidad, está el [apéndice de `IdP` externos](#apendice-idp-externos).
 
----
+### auth propia
+
+Conviene cuando el equipo necesita controlar de punta a punta cómo se resuelven login, sesión, emisión de tokens y manejo de credenciales, o cuando esa implementación forma parte de lo que después va a tener que defender técnicamente. Eso incluye registro, login, hashing, recupero, refresh tokens y emisión de JWT.
+
+No implica escribir todo desde cero —Spring Authorization Server, las utilidades OAuth2/JWT de FastAPI o `node-oidc-provider` cubren una parte importante del trabajo commodity— pero la seguridad, la operación y las garantías siguen siendo del equipo. ([Spring Auth Server][36], [FastAPI Security][37], [node-oidc-provider][38])
+
+Vale distinguir también entre auth para la propia app y un authorization server OAuth/OIDC reutilizable para terceros. Lo segundo involucra mucho más superficie, y mezclar los dos objetivos es una fuente frecuente de scope creep en el proyecto.
+
+| Trade-off     | Detalle                                                                                                                                                                                         |
+| :------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A favor**   | Control total sobre identidad, sesiones y claims. Es la opción correcta si el equipo necesita flujos propios, independencia del proveedor o demostrar garantías que ellos mismos implementaron. |
+| **A favor**   | Con librerías modernas, el volumen de código commodity es bastante menor de lo que sugiere la intuición inicial.                                                                                |
+| **En contra** | Seguridad, sesiones, recupero, almacenamiento seguro, revocación, auditoría y mitigaciones de abuso quedan bajo responsabilidad del equipo. ([OWASP AuthN][39], [OWASP Passwords][35])          |
+
+### IdP externo
+
+Si el equipo no quiere construir login, sesión y recuperación desde cero, puede delegar esa parte en un `IdP` externo. La decisión real no es “usar Firebase o no”, sino qué parte de identidad resuelve el proveedor y qué parte sigue siendo responsabilidad de la plataforma.
+
+Lo que ningún proveedor resuelve por ustedes es si el usuario está bloqueado, qué recursos son suyos, qué flags de negocio aplican y cómo se decide la `fine-grained authorization`. Eso sigue siendo responsabilidad del equipo y debe persistirse en el sistema independientemente de quién emite el token. Si quieren comparar proveedores concretos, vean el [apéndice de `IdP` externos](#apendice-idp-externos). ([Firebase Auth][19], [Clerk Quickstart][30], [Keycloak][49], [Supabase Auth][44])
 
 ### Criterio de validez
 
-Un `IdP externo` solo es defendible si el equipo puede demostrar, con documentación oficial y diseño propio, los controles que realmente delega:
+La regla es simple: la cátedra pide un piso de controles. Si hacen `auth propia`, ustedes lo implementan. Si usan un `IdP` externo, tienen que poder demostrar que ese proveedor cubre ese mismo piso.
 
-- login, registro y recupero;
-- sesión y refresh, si aplica;
-- hashing de contraseñas con `BCrypt` o equivalente, siempre que el sistema elegido lo resuelva;
-- tokens de recupero con TTL, single-use y tratamiento seguro, siempre que el sistema elegido cubra esas garantías;
+Como mínimo:
 
-Si el proveedor no permite demostrar alguno de esos puntos, no alcanza con responder "eso lo maneja el IdP". En ese caso, para efectos de arquitectura y corrección, la opción no queda legitimada y conviene pasar a `auth propia`, que sí permite implementar y probar todos los controles requeridos.
+- `sign-up`, `login` y `password reset`. ([OWASP AuthN][39], [OWASP Forgot Password][69])
+- política mínima de contraseñas y hashing adaptativo, por ejemplo `BCrypt` o equivalente. ([OWASP AuthN][39], [OWASP Passwords][35])
+- `password reset token` de uso único, expiración máxima de 1 hora y manejo seguro: suficiente entropía, almacenamiento seguro y sin exposición en logs. ([OWASP Forgot Password][69])
+- renovación de sesión, típicamente con `refresh token` o mecanismo equivalente. ([OAuth Refresh Tokens][70], [OWASP AuthN][39])
+- `rate limiting` para `login` y `password reset`, por IP y por cuenta. ([OWASP AuthN][39], [OWASP Forgot Password][69])
 
-## Matices con IdP externos
+Elegir un `IdP` externo no se justifica solo por ir más rápido. Si ese piso no puede demostrarse con precisión y con evidencia oficial, delegar identidad no alcanza como defensa arquitectónica. En ese caso, la opción que queda bien defendida es `auth propia`.
 
-Los proveedores externos resuelven bien login, sesión, recupero e integración federada, pero no reemplazan el estado propio del dominio ni la autorización fina. En esta guía se usa Firebase como ejemplo frecuente por su adopción en mobile, no como única opción válida. Trabajar sobre OIDC/OAuth2 reduce el costo de cambio, aunque no elimina por completo el vendor lock-in. ([OpenID Connect][40], [Firebase][19])
+## Checklist ADR
 
-**Sesión, claims, revocación y bloqueo**
+- ¿Qué valida el borde y qué necesita decidir el servicio que ejecuta la operación?
+- ¿Qué decisiones se toman con claims del token y cuáles dependen del estado actual del dominio?
+- ¿Qué datos externos al token necesita la autorización y de qué servicio salen?
+- ¿Cómo llega la identidad al backend: token original, token intercambiado o contexto propagado?
+- ¿Qué componente toma la decisión final y por qué ese componente tiene los datos correctos para tomarla?
+- ¿Qué parte se delega al IdP y qué parte sigue siendo responsabilidad propia?
+- ¿Qué limitación concreta de la solución elegida aceptamos a cambio de sus beneficios?
 
-Aunque Firebase permite gestionar usuarios y aprovisionarlos deshabilitados, eso no reemplaza el estado propio del dominio. Sigue siendo necesario persistir `user_id interno`, `blocked`, `roles`, `created_at` y flags de negocio; y no depender solo de claims externas para authz fina.
+## Apéndice: Matriz operativa
 
-La razón es concreta: `verifyIdToken()` por sí solo no chequea revocación, y un gateway que valida offline por firma/JWKS tampoco ve instantáneamente `disabled=true` ni una revocación. Los ID tokens ya emitidos pueden seguir válidos hasta su expiración natural. Por eso `blocked`, roles reales y reglas finas deben consultarse contra estado propio del dominio, ya sea dentro del servicio o a través de una capa central de autorización. ([Firebase][21], [OPA][32])
+Si necesitás una referencia más exhaustiva para ADR o corrección, esta es la versión detallada de responsabilidades por capa.
 
-Firebase soporta custom claims para roles globales tipo `admin`, pero no están pensadas para datos estructurados de negocio, y los cambios se reflejan solo cuando el usuario reautentica o refresca el token. **Claim o scope para authz gruesa; dominio o capa de autorización para authz fina.** ([Firebase][20], [OAuth Resource Server][34])
+| Responsabilidad                               | ¿Pasa por el gateway?        | Dónde se implementa                                |
+| :-------------------------------------------- | :--------------------------- | :------------------------------------------------- |
+| `Login` federado con Google (optativo)        | No (valida el token después) | `IdP` externo                                      |
+| `Login` con email/password                    | No                           | `IdP` externo o `auth propia`                      |
+| Registro con email/password                   | No                           | `IdP` externo o `auth propia`                      |
+| Recupero de contraseña                        | No                           | `IdP` externo o `auth propia`                      |
+| Hash de contraseñas (ej. `BCrypt` o `scrypt`) | No                           | Delegado al `IdP` o resuelto por `auth propia`     |
+| Reglas mínimas de contraseña                  | No                           | Depende de la opción de identidad elegida          |
+| Renovación de sesión                          | No                           | Depende de la opción de identidad elegida          |
+| Emisión del token de API                      | No (solo valida)             | `IdP` o `auth service` propio                      |
+| Validación del token de API                   | Sí                           | `gateway`                                          |
+| Decisión de `fine-grained authorization`      | No                           | `Domain services` o `Authorization Layer`          |
+| `Rate limiting` por IP                        | Sí                           | `gateway`                                          |
+| `Rate limiting` por cuenta/email              | Parcial (ver nota)           | `auth service`                                     |
+| Bloqueo de usuario                            | No                           | Backend + DB de dominio                            |
+| Roles básicos (`user`/`admin`)                | Parcial (`claims`/`scopes`)  | Estado real en DB propia                           |
+| `Ownership` y `fine-grained authorization`    | No                           | Enforcement final en backend con datos del dominio |
+| Minimización de datos                         | No                           | Backend del dominio                                |
+| Ocultar recursos de usuario bloqueado         | No                           | Backend + queries de dominio                       |
+| Idempotencia de operaciones críticas          | No                           | Servicios de dominio                               |
+| `/livez` y `/readyz`                          | No                           | Cada servicio, incluido auth/user                  |
 
-**Password reset y hashing**
-
-Firebase envía password reset emails con expiración del código y single-use del flujo. Lo que no está verificable en documentación oficial es un TTL máximo de 1 hora ni el almacenamiento hasheado del token del lado del proveedor. Si el sistema elegido no cubre esas garantías con claridad, hay que implementarlas en un auth service propio. ([Firebase][23])
-
-Respecto del hashing de contraseñas: las contraseñas que viven en Firebase nunca tocan la DB propia, así que el hashing queda delegado al proveedor. Firebase usa por defecto una versión modificada de `scrypt` — probablemente "otro algoritmo adaptativo" — pero sigue siendo un control delegado. ([Firebase][22])
-
-
----
-
-## Responsabilidades por capa
-
-| Responsabilidad                           | ¿Pasa por el gateway?        | Dónde se implementa                                 |
-| :---------------------------------------- | :--------------------------- | :-------------------------------------------------- |
-| Login federado con Google (optativo)      | No (valida el token después) | IdP externo                                         |
-| Login con email/password                  | No                           | IdP externo o auth propia                           |
-| Registro con email/password               | No                           | IdP externo o auth propia                           |
-| Recupero de contraseña                    | No                           | IdP externo o auth propia                           |
-| Hash de contraseñas (ej. BCrypt o scrypt) | No                           | Delegado al IdP o resuelto por auth propia          |
-| Reglas mínimas de contraseña              | No                           | Depende de la opción de identidad elegida           |
-| Renovación de sesión                      | No                           | Depende de la opción de identidad elegida           |
-| Emisión del token de API                  | No (solo valida)             | IdP o auth service propio                           |
-| Validación del token de API               | Sí                           | Gateway                                             |
-| Decisión de autorización fina             | No                           | Servicios de dominio o capa central de autorización |
-| Rate limiting por IP                      | Sí                           | Gateway                                             |
-| Rate limiting por cuenta/email            | Parcial (ver nota)           | Auth service                                        |
-| Bloqueo de usuario                        | No                           | Backend + DB de dominio                             |
-| Roles básicos (`user`/`admin`)            | Parcial (claims gruesas)     | Estado real en DB propia                            |
-| Ownership y permisos finos                | No                           | Enforcement final en backend con datos del dominio  |
-| Minimización de datos                     | No                           | Backend del dominio                                 |
-| Ocultar recursos de usuario bloqueado     | No                           | Backend + queries de dominio                        |
-| Idempotencia de operaciones críticas      | No                           | Servicios de dominio                                |
-| `/livez` y `/readyz`                      | No                           | Cada servicio, incluido auth/user                   |
-
-**Nota sobre rate limiting por cuenta/email:** El gateway resuelve bien rate limiting por IP, header o token. El rate limiting por cuenta/email en login o recupero conviene implementarlo en el auth service: el identificador suele venir en el body y requiere lógica de dominio. ([KrakenD][14])
+**Nota.** `Rate limiting` por cuenta/email suele caer en `auth service` porque el identificador viene en el body. `claims` y `scopes` sirven para `coarse-grained authorization`, pero no reemplazan `fine-grained authorization` ni el estado real del dominio. ([KrakenD Rate Limit][14], [OAuth Resource Server][34])
 
 ---
 
-## Errores comunes
+## Apéndice: Gateways
 
-1. **Centralizar autorización en el gateway.** El gateway verifica si una ruta es protegida o un rol global grueso; no resuelve ownership ni reglas de negocio.
-2. **Descartar Kong OSS.** Con un JWT emitido por el propio equipo es válido. La fricción aparece solo en OIDC/Firebase directo (OpenID Connect es Enterprise). ([Kong JWT][25], [Kong OIDC][8])
-3. **Implementar refresh token propio si el IdP ya resuelve la sesión larga.** Superficie de ataque innecesaria. ([Firebase][18])
-4. **Confiar únicamente en claims externas para reglas finas.** `admin=true` no valida "este recurso es de este usuario". ([Firebase][20])
-5. **Asumir revocación/disable instantáneos sobre tokens ya emitidos.** El gateway que valida offline por firma/JWKS no se entera automáticamente. ([Firebase][21])
-6. **Afirmar atributos de seguridad que no pueden demostrarse.** Si el reset o el hashing están delegados al proveedor, no inventar detalles técnicos sobre código que no controlan.
-7. **Elegir un IdP externo como salida rápida sin justificar la decisión.** Si no hay una defensa explícita de qué garantías cubre, qué queda delegado y por qué eso sigue cumpliendo la consigna, la decisión está floja de base.
-8. **Asumir que la authz fina debe vivir exclusivamente en cada microservicio o, al revés, exclusivamente en el gateway.** La decisión puede centralizarse, pero necesita datos del dominio y un enforcement claro cerca del recurso protegido. ([OPA][32], [Keycloak Authz][33])
+Con el diseño claro, recién tiene sentido bajar a productos.
+
+| Producto                      | Modelo mental                       | Encaja mejor cuando...                                                          | Ojo con...                                                                                                                                                                                                  |
+| :---------------------------- | :---------------------------------- | :------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Traefik OSS + ForwardAuth** | application proxy con auth delegada | querés delegar autenticación a un servicio externo y mantener el gateway simple | `ForwardAuth` está en OSS, pero la historia fuerte de OIDC aparece en Traefik Hub. ([Traefik Features][5], [Traefik ForwardAuth][29], [Traefik Docker][28], [Traefik Hub OIDC][57])                         |
+| **KrakenD CE**                | BFF / API gateway declarativo       | buscás validación local de JWT y agregación/BFF con pocas piezas                | no es el caso más natural para una arquitectura basada en auth service externo por request. ([KrakenD JWT][1], [KrakenD Docker][10], [API Gateway Pattern][59])                                             |
+| **Tyk OSS**                   | gateway más "batteries included"    | querés buen encaje con `IdP` externo y una superficie más fuerte de policies    | arrastra Redis como costo operativo. ([Tyk OSS][3], [Tyk Install][7], [Tyk OIDC][13])                                                                                                                       |
+| **Kong OSS**                  | gateway plugin-based                | te sirve validación local de JWT/JWKS, routing y rate limiting                  | el plugin `JWT` OSS encaja bien; `OpenID Connect` e introspection figuran como capacidades Enterprise. ([Kong DB-less][4], [Kong JWT][25], [Kong JWT Claims][64], [Kong OIDC][8], [Kong Introspection][56]) |
+| **Apache APISIX**             | gateway cloud-native de plugins     | querés flexibilidad con `openid-connect`, introspection y RP flow               | la flexibilidad viene con más configuración explícita. ([Apache APISIX][2], [APISIX Deploy][26])                                                                                                            |
+
+**Sin Kubernetes:** todas estas opciones corren con contenedores. ([KrakenD Docker][10], [Tyk OSS][3], [Kong Docker][27], [Traefik Docker][28], [APISIX Deploy][26])
+
+---
+
+## Apéndice: IdP externos
+
+Esto sirve como referencia rápida de opciones concretas. Primero definan el criterio de validez; recién después comparen proveedor.
+
+| Opción                      | Tipo                                   | Qué simplifica                                                                                                                                  | Trade-off principal                                                                                                                           |
+| :-------------------------- | :------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Clerk**                   | IdP gestionado                         | UI prearmada para `sign-in`, perfil y flujos comunes; integración rápida. ([Clerk Pricing][41], [Clerk SignIn][42], [Clerk UserProfile][43])    | Muy poca fricción, pero más dependencia de un servicio cerrado.                                                                               |
+| **Firebase Authentication** | IdP gestionado, muy usado en mobile    | Email/password, reset, proveedores federados y buen encaje con apps mobile. ([Firebase Auth][19])                                               | Muy práctico, pero varias garantías finas siguen delegadas al proveedor.                                                                      |
+| **Supabase Auth**           | Auth integrada a plataforma backend    | Password, magic link, OTP, social login y buen fit si también usan DB/storage de Supabase. ([Supabase Auth][44], [Supabase Billing][45])        | Cómodo, pero suma dependencia de plataforma, no solo de identidad.                                                                            |
+| **Auth0**                   | Plataforma de identidad más enterprise | Passwordless, social login, custom domains y conexiones enterprise. ([Auth0 Pricing][46], [Auth0 Custom Domains][47], [Auth0 Passwordless][48]) | Muy completo, pero puede sentirse más pesado que otras opciones de esta guía.                                                                 |
+| **Keycloak**                | IdP self-hosted / auth server          | OIDC, OAuth2, SAML, consola admin y Authorization Services. ([Keycloak][49], [Keycloak Admin][52], [Keycloak Authz][33])                        | Resuelve mucho sin `auth propia`, pero hay que operarlo: contenedor, DB y configuración propia. ([Keycloak Container][50], [Keycloak DB][51]) |
 
 ---
 
-## Checklist para el ADR
+## Apéndice: Caso Firebase
 
-- ¿Dónde vive la identidad? ¿Quién emite el token que entra a la API?
-- ¿Qué valida el gateway y qué verifica cada microservicio?
-- ¿Cómo se renueva la sesión?
-- ¿Dónde se persiste el estado del usuario (bloqueo, roles, flags de negocio)?
-- ¿Qué garantías quedan delegadas al proveedor, cuáles implementadas por el equipo, y qué brechas quedan asumidas?
-- ¿Qué nivel de acoplamiento al proveedor aceptan y cuánto costaría migrar?
-- ¿Por qué esa elección es defendible ante la cátedra y no solo una reducción de esfuerzo?
+Firebase aparece mucho en proyectos mobile y por eso tiende a colonizar el vocabulario del diseño. Vale entender bien qué resuelve y qué no.
 
----
+- `verifyIdToken()` no chequea revocación. Un gateway que valida offline tampoco ve `disabled=true` de forma inmediata. Un usuario bloqueado puede seguir pasando la barra práctica si su token no venció. ([Firebase Verify][21], [Token Introspection][53])
+- Los custom `claims` sirven para `coarse-grained authorization`, no como depósito de datos de negocio. Los cambios se propagan solo cuando el usuario reautentica o refresca el token. ([Firebase Claims][20], [OAuth Resource Server][34])
+- Hashing y reset son controles delegados. Si la cátedra exige garantías precisas sobre TTL máximo, single-use o almacenamiento del token de reset, hay que poder demostrarlas con documentación oficial. Si no, hay que implementarlas. ([Firebase Scrypt][22], [Firebase REST Auth][23], [Firebase Admin][63])
 
 [1]: https://www.krakend.io/docs/authorization/jwt-validation/
 [2]: https://apisix.apache.org/docs/apisix/plugins/openid-connect/
@@ -232,7 +375,7 @@ Respecto del hashing de contraseñas: las contraseñas que viven en Firebase nun
 [10]: https://www.krakend.io/docs/deploying/docker/
 [11]: https://apisix.apache.org/docs/apisix/deployment-modes/
 [12]: https://doc.traefik.io/traefik/v3.4/middlewares/http/ratelimit/
-[13]: https://tyk.io/docs/api-management/gateway-config-tyk-oas
+[13]: https://tyk.io/docs/basic-config-and-security/security/authentication-authorization/openid-connect/overview/
 [14]: https://www.krakend.io/docs/endpoints/rate-limit/
 [15]: https://apisix.apache.org/docs/apisix/plugins/limit-count/
 [16]: https://tyk.io/docs/5.0/basic-config-and-security/control-limit-traffic/rate-limiting/
@@ -248,7 +391,7 @@ Respecto del hashing de contraseñas: las contraseñas que viven en Firebase nun
 [26]: https://apisix.apache.org/docs/apisix/installation-guide/
 [27]: https://developer.konghq.com/gateway/install/docker-read-only/
 [28]: https://doc.traefik.io/traefik/setup/docker/
-[29]: https://doc.traefik.io/traefik/v3.4/middlewares/http/forwardauth/
+[29]: https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/forwardauth/
 [30]: https://clerk.com/docs/expo/getting-started/quickstart
 [31]: https://clerk.com/docs/guides/force-token-refresh
 [32]: https://www.openpolicyagent.org/docs/external-data
@@ -272,3 +415,21 @@ Respecto del hashing de contraseñas: las contraseñas que viven en Firebase nun
 [50]: https://www.keycloak.org/server/containers
 [51]: https://www.keycloak.org/server/db
 [52]: https://www.keycloak.org/docs/latest/server_admin/
+[53]: https://www.rfc-editor.org/rfc/rfc7662.html
+[54]: https://www.rfc-editor.org/rfc/rfc8693.html
+[55]: https://www.rfc-editor.org/rfc/rfc9068
+[56]: https://developer.konghq.com/plugins/oauth2-introspection/
+[57]: https://doc.traefik.io/traefik-hub/api-gateway/secure/middleware/oidc
+[58]: https://microservices.io/post/architecture/2025/04/25/microservices-authn-authz-part-1-introduction.html
+[59]: https://microservices.io/patterns/apigateway.html
+[60]: https://learn.microsoft.com/en-us/azure/api-management/authentication-authorization-overview
+[61]: https://cloud.google.com/blog/products/api-management/identity-propagation-in-an-api-gateway-architecture
+[62]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ext_authz_filter.html
+[63]: https://firebase.google.com/docs/auth/admin
+[64]: https://developer.konghq.com/plugins/jwt/examples/verified-claim/
+[65]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-228.pdf
+[66]: https://learn.microsoft.com/en-us/azure/well-architected/architect-role/design-diagrams
+[67]: https://curity.io/resources/learn/claims-best-practices/
+[68]: https://microservices.io/post/architecture/2025/07/22/microservices-authn-authz-part-3-jwt-authorization.html
+[69]: https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html
+[70]: https://oauth.net/2/refresh-tokens/

--- a/content/tps/2026/01/enunciado.md
+++ b/content/tps/2026/01/enunciado.md
@@ -1414,6 +1414,8 @@ Cada servicio debe contar con log estructurado con niveles configurables:
 - **Refresh de sesión**: Se debe soportar renovación de token sin requerir re-autenticación mientras la sesión sea válida.
 - **Rate limiting**: Los endpoints de login y recupero deben tener límite de intentos por IP y por cuenta.
 
+Para una guía más detallada sobre alternativas de autenticación, manejo de sesión, API Gateway y separación entre auth/authz, consultar la **[Guía de cátedra 2026: API Gateway + Auth/Authz](https://ingenieria-del-software-2.github.io/blog/2026-04-03-auth/)**.
+
 ### Documentación
 
 Se debe entregar:


### PR DESCRIPTION
This MR adds a new API Gateway + Auth/Authz guide

Students kept running into the same questions around identity, sessions, gateways, and provider trade-offs. This adds a reusable reference to make those decisions clearer.