### PR TITLE
chore(team): actualizar plantel docente vigente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ ehthumbs.db
 
 node_modules/
 hugo_stats.json
+
+# YouTube admin credentials (local only, never commit)
+.env.youtube

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -54,11 +54,6 @@ team:
     mail: "gfrenkel@fi.uba.ar"
     github: "gstfrenkel"
 
-  - name: Juan Ignacio Giacobbe
-    pic: "/images/professors/juan.jpeg"
-    mail: "jgiacobbed@fi.uba.ar"
-    github: "juanignaciogiacobbe"
-
   - name: Iara Elizabeth Jolodovsky
     pic: "/images/professors/iara.jpg"
     mail: "ijolodovsky@fi.uba.ar"

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -9,16 +9,6 @@ team:
     mail: "icarol@fi.uba.ar"
     github: "IgnacioCarol"
 
-  - name: Matias Fonseca
-    pic: "/images/professors/fonseca.png"
-    mail: "mfonseca@fi.uba.ar"
-    github: "matfonseca"
-
-  - name: Nicolás Pablo Fernández Theillet
-    pic: "/images/professors/nico.jpeg"
-    mail: "nflabo@gmail.com"
-    github: "npfernandeztheillet"
-
   - name: Paulo Cuneo
     pic: "/images/professors/paulo.jpeg"
     mail: "cuneo.paulo.cesar@gmail.com"
@@ -73,11 +63,6 @@ team:
     pic: "/images/professors/niko.jpg"
     mail: "nrsanchez@fi.uba.ar"
     github: "nikorsanchez"
-
-  - name: Daniela Ailin Vela
-    pic: "/images/professors/daniela.jpeg"
-    mail: "davela@fi.uba.ar"
-    github: "noxethiems"
 
   - name: Thiago Pacheco
     pic: "/images/professors/thiago.jpeg"


### PR DESCRIPTION
## Summary
- Ignora `.env.youtube` (credenciales locales, quedó pendiente de una tarea anterior)
- Quita del plantel a docentes que ya no forman parte del equipo: Juan Ignacio Giacobbe, Matias Fonseca, Nicolás Pablo Fernández Theillet, Daniela Ailin Vela

## Test plan
- [ ] Verificar que la página de team se renderiza correctamente sin los 4 removidos