### PR TITLE
feat(programa): agregar sección de Programa de la materia

### DIFF
--- a/content/programa/_index.md
+++ b/content/programa/_index.md
@@ -1,0 +1,81 @@
+---
+title: "Programa"
+description: "Qué se enseña en Ingeniería del Software II: los módulos del programa y cómo los llevamos a la práctica."
+subtitle: "Qué vas a aprender"
+---
+
+No enseñamos un lenguaje ni un framework — esos cambian cada dos años. Enseñamos cómo se construye software cuando el código deja de ser lo difícil: cuando hay un equipo de por medio, un sistema que no puede caerse, y decisiones que se pagan varias semanas después de haberlas tomado.
+
+El programa está organizado en 6 módulos, que son también los 6 ejes que definen la materia ante la Facultad. Acá van con los temas concretos que dictamos hoy en cada uno — no la versión de hace diez años.
+
+---
+
+## 1. Fundamentos de la Ingeniería de Software Moderna
+
+El punto de partida: cómo se construye software guiado por pruebas, y cómo se especifica lo que hay que construir antes de escribir la primera línea.
+
+**En la práctica:**
+- Arquitectura de soluciones: monolito vs. microservicios, package by layer, stateless vs. stateful
+- REST: historia, REST-like vs. RESTful, por qué una API REST
+- Testing E2E / de integración
+- TDD, Especificación con Ejemplos, Gherkin y Cucumber
+- Desarrollo incremental (baby steps), Definición de Listo y Definición de Hecho
+
+## 2. Enfoque de Orientación al Dominio
+
+Cómo modelar el problema antes de modelar el código — para que la arquitectura refleje el negocio, no al revés.
+
+**En la práctica:**
+- Domain-Driven Design: bounded contexts, lenguaje ubicuo, modelado táctico
+- Arquitectura Hexagonal y Clean Architecture
+- MVC y decisiones de arquitectura en general
+
+## 3. Calidad
+
+Que funcione no es el objetivo — es el piso. Acá se trata de saber en qué se está fallando antes de que lo note un usuario.
+
+**En la práctica:**
+- Atributos de calidad, internos y externos
+- Cuadrantes de Marick y pirámide de automatización de pruebas
+- Dobles de prueba: tipos y usos
+- Testing a escala
+
+## 4. Gestión
+
+El código no se entrega solo. Este módulo es sobre cómo un equipo decide qué construir primero, cómo se organiza, y qué hacer cuando alguien no está de acuerdo.
+
+**En la práctica:**
+- Metodologías ágiles: Scrum (artefactos, eventos, implementación), fundamentos de Kanban y XP
+- Roles y responsabilidades, matriz RACI
+- Recopilación y validación de requisitos, Producto Mínimo Viable, priorización de backlog
+- Comunicación osmótica, auto-organización, Pair y Mob Programming
+- Escalamiento del proceso ágil (SAFe, Nexus, LeSS)
+
+## 5. Control de Configuración
+
+Cómo se versiona, se revisa y se empaqueta el trabajo de un equipo entero sin pisarse.
+
+**En la práctica:**
+- Contenedores: arquitectura de imágenes, Dockerfile, Docker Compose, networking, registries
+- Trunk-Based Development y Conventional Commits
+- Revisiones de código y linting
+
+## 6. Despliegue y Operación
+
+Escribir el código es la mitad del trabajo. La otra mitad es que siga andando cuando ustedes no están mirando.
+
+**En la práctica:**
+- Historia de DevOps: del Lean Movement al Continuous Delivery
+- Cloud Computing e Infraestructura como Código (AWS: VPC, EC2, IAM, S3)
+- Operaciones y el modelo SRE: monitoreo, alarmas, incidentes, on-call
+- Blue-green, canary deployments, feature flags, SLAs
+
+---
+
+### Además, del lado del stack
+
+React y React Native aparecen de forma transversal — como el vehículo con el que se construyen las interfaces de cada trabajo práctico, no como un módulo aparte. Se dan las bases (componentes, hooks, estado, estrategias de renderizado) para que el foco del cuatrimestre siga estando en los 6 módulos de arriba.
+
+---
+
+_Este programa surge de los contenidos mínimos aprobados por el Consejo Superior para la asignatura (Plan TA049 y equivalentes), adaptados cuatrimestre a cuatrimestre al proyecto grupal en curso. Para el detalle de cómo se evalúa, ver el [Régimen de Aprobación](../regimen)._

--- a/content/programa/_index.md
+++ b/content/programa/_index.md
@@ -72,10 +72,4 @@ Escribir el código es la mitad del trabajo. La otra mitad es que siga andando c
 
 ---
 
-### Además, del lado del stack
-
-React y React Native aparecen de forma transversal — como el vehículo con el que se construyen las interfaces de cada trabajo práctico, no como un módulo aparte. Se dan las bases (componentes, hooks, estado, estrategias de renderizado) para que el foco del cuatrimestre siga estando en los 6 módulos de arriba.
-
----
-
 _Este programa surge de los contenidos mínimos aprobados por el Consejo Superior para la asignatura (Plan TA049 y equivalentes), adaptados cuatrimestre a cuatrimestre al proyecto grupal en curso. Para el detalle de cómo se evalúa, ver el [Régimen de Aprobación](../regimen)._

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -63,6 +63,10 @@ menu:
       pageRef: "/regimen"
       weight: 3
 
+    - name: "Programa"
+      pageRef: "/programa"
+      weight: 4
+
     - name: "TPs"
       pageRef: "/tps"
       weight: 5


### PR DESCRIPTION
## Summary
- Nueva página `/programa` con los 6 módulos del contenido analítico oficial (Consejo Superior, Plan TA049 y equivalentes), combinando esa estructura con los temas reales que se dictan en el cronograma actual (Docker, DDD, Cloud/AWS, Gestión de Proyectos, SRE, etc.)
- Se agrega al menú principal entre "Regimen" y "TPs"

## Test plan
- [x] `npm run build` corre sin errores y genera `public/programa/`
- [ ] Revisar visualmente en `npm run dev`